### PR TITLE
feat: User-friendly error messages instead of stack traces

### DIFF
--- a/src/commands/block/delete.ts
+++ b/src/commands/block/delete.ts
@@ -3,7 +3,7 @@ import * as notion from '../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError } from '../../errors/enhanced-errors'
 
 export default class BlockDelete extends Command {
   static description = 'Delete a block'
@@ -81,11 +81,15 @@ export default class BlockDelete extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        userInput: args.block_id,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/block/retrieve.ts
+++ b/src/commands/block/retrieve.ts
@@ -3,7 +3,7 @@ import * as notion from '../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError } from '../../errors/enhanced-errors'
 
 export default class BlockRetrieve extends Command {
   static description = 'Retrieve a block'
@@ -81,11 +81,15 @@ export default class BlockRetrieve extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        userInput: args.block_id,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/block/retrieve/children.ts
+++ b/src/commands/block/retrieve/children.ts
@@ -3,7 +3,7 @@ import * as notion from '../../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { wrapNotionError } from '../../../errors/enhanced-errors'
 
 export default class BlockRetrieveChildren extends Command {
   static description = 'Retrieve block children'
@@ -84,11 +84,15 @@ export default class BlockRetrieveChildren extends Command {
       ux.table(res.results, columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        endpoint: 'blocks.children.list',
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/db/create.ts
+++ b/src/commands/db/create.ts
@@ -6,7 +6,7 @@ import {
 import * as notion from '../../notion'
 import { outputRawJson, getDbTitle } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { wrapNotionError, NotionCLIErrorFactory } from '../../errors/enhanced-errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbCreate extends Command {
@@ -118,11 +118,15 @@ export default class DbCreate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'database',
+        attemptedId: args.page_id,
+        userInput: args.page_id,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/db/retrieve.ts
+++ b/src/commands/db/retrieve.ts
@@ -10,7 +10,7 @@ import {
   showRawFlagHint
 } from '../../helper'
 import { AutomationFlags, OutputFormatFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { wrapNotionError, NotionCLIErrorFactory } from '../../errors/enhanced-errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbRetrieve extends Command {
@@ -131,11 +131,15 @@ export default class DbRetrieve extends Command {
       showRawFlagHint(1, res)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'database',
+        attemptedId: args.database_id,
+        userInput: args.database_id,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/db/schema.ts
+++ b/src/commands/db/schema.ts
@@ -13,7 +13,7 @@ import {
   groupExamplesByWritability,
   PropertyExample,
 } from '../../utils/schema-examples'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError, NotionCLIErrorFactory } from '../../errors/enhanced-errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbSchema extends Command {
@@ -206,12 +206,16 @@ export default class DbSchema extends Command {
       this.outputTable(schema)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'database',
+        attemptedId: args.data_source_id,
+        userInput: args.data_source_id,
+      })
 
       if (flags.json || flags.output === 'json') {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
 
       process.exit(1)

--- a/src/commands/db/update.ts
+++ b/src/commands/db/update.ts
@@ -6,7 +6,7 @@ import {
 import * as notion from '../../notion'
 import { outputRawJson, getDataSourceTitle } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { wrapNotionError, NotionCLIErrorFactory } from '../../errors/enhanced-errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbUpdate extends Command {
@@ -109,11 +109,15 @@ export default class DbUpdate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'database',
+        attemptedId: args.database_id,
+        userInput: args.database_id,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/page/retrieve.ts
+++ b/src/commands/page/retrieve.ts
@@ -12,7 +12,7 @@ import {
 import { NotionToMarkdown } from 'notion-to-md'
 import { AutomationFlags, OutputFormatFlags } from '../../base-flags'
 import { resolveNotionId } from '../../utils/notion-resolver'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError, handleCliError } from '../../errors/enhanced-errors'
 
 export default class PageRetrieve extends Command {
   static description = 'Retrieve a page'
@@ -154,11 +154,16 @@ export default class PageRetrieve extends Command {
       // Show hint after table output to make -r flag discoverable
       showRawFlagHint(1, res)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'page',
+        attemptedId: args.page_id,
+        userInput: args.page_id
+      })
+
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/page/retrieve/property_item.ts
+++ b/src/commands/page/retrieve/property_item.ts
@@ -2,7 +2,7 @@ import { Args, Command, Flags } from '@oclif/core'
 import * as notion from '../../../notion'
 import { outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { wrapNotionError } from '../../../errors/enhanced-errors'
 
 export default class PageRetrievePropertyItem extends Command {
   static description = 'Retrieve a page property item'
@@ -58,11 +58,16 @@ export default class PageRetrievePropertyItem extends Command {
       outputRawJson(res)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'page',
+        attemptedId: args.page_id,
+        endpoint: 'pages.properties.retrieve',
+        metadata: { propertyId: args.property_id },
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,7 +18,7 @@ import {
   showRawFlagHint
 } from '../helper'
 import { AutomationFlags, OutputFormatFlags } from '../base-flags'
-import { wrapNotionError } from '../errors'
+import { wrapNotionError } from '../errors/enhanced-errors'
 
 export default class Search extends Command {
   static description = 'Search by title'
@@ -232,11 +232,14 @@ export default class Search extends Command {
         showRawFlagHint(res.results.length, res.results[0])
       }
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        endpoint: 'search',
+        userInput: flags.query,
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -11,7 +11,7 @@ import {
 } from '../utils/workspace-cache'
 import { getDataSourceTitle } from '../helper'
 import { AutomationFlags } from '../base-flags'
-import { NotionCLIError, wrapNotionError } from '../errors'
+import { NotionCLIError, wrapNotionError } from '../errors/enhanced-errors'
 import { DataSourceObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as os from 'os'
 import * as path from 'path'
@@ -146,13 +146,16 @@ export default class Sync extends Command {
 
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'database',
+        endpoint: 'search',
+      })
 
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
         ux.action.stop('failed')
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
 
       process.exit(1)

--- a/src/commands/user/list.ts
+++ b/src/commands/user/list.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../notion'
 import { outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError } from '../../errors/enhanced-errors'
 
 export default class UserList extends Command {
   static description = 'List all users'
@@ -82,11 +82,13 @@ export default class UserList extends Command {
       ux.table(res.results, columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'user'
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/user/retrieve.ts
+++ b/src/commands/user/retrieve.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../notion'
 import { outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { wrapNotionError } from '../../errors/enhanced-errors'
 
 export default class UserRetrieve extends Command {
   static description = 'Retrieve a user'
@@ -86,11 +86,15 @@ export default class UserRetrieve extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'user',
+        attemptedId: args.user_id,
+        userInput: args.user_id
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/user/retrieve/bot.ts
+++ b/src/commands/user/retrieve/bot.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../../notion'
 import { outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { wrapNotionError } from '../../../errors/enhanced-errors'
 
 export default class UserRetrieveBot extends Command {
   static description = 'Retrieve a bot user'
@@ -84,11 +84,14 @@ export default class UserRetrieveBot extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
+      const cliError = wrapNotionError(error, {
+        resourceType: 'user',
+        endpoint: 'users.me',
+      })
       if (flags.json) {
         this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.error(cliError.message)
+        this.error(cliError.toHumanString())
       }
       process.exit(1)
     }

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from '@oclif/core'
 import { AutomationFlags } from '../base-flags'
 import * as notion from '../notion'
 import { cacheManager } from '../cache'
-import { wrapNotionError, ErrorCode, NotionCLIError } from '../errors'
+import { wrapNotionError, NotionCLIErrorCode, NotionCLIError, NotionCLIErrorFactory } from '../errors/enhanced-errors'
 import { loadCache } from '../utils/workspace-cache'
 
 export default class Whoami extends Command {
@@ -36,18 +36,7 @@ export default class Whoami extends Command {
     try {
       // Verify NOTION_TOKEN is set
       if (!process.env.NOTION_TOKEN) {
-        const error = new NotionCLIError(
-          ErrorCode.UNAUTHORIZED,
-          'NOTION_TOKEN environment variable is not set',
-          {
-            suggestions: [
-              'Set token: export NOTION_TOKEN="your-token-here"  # Mac/Linux',
-              'Set token: set NOTION_TOKEN=your-token-here       # Windows CMD',
-              'Set token: $env:NOTION_TOKEN="your-token-here"    # Windows PowerShell',
-              'Get new token: https://developers.notion.com/docs/create-a-notion-integration',
-            ]
-          }
-        )
+        const error = NotionCLIErrorFactory.tokenMissing()
 
         if (flags.json) {
           this.log(JSON.stringify({
@@ -55,7 +44,7 @@ export default class Whoami extends Command {
             error: {
               code: error.code,
               message: error.message,
-              suggestions: error.details?.suggestions || [],
+              suggestions: error.suggestions,
             },
             metadata: {
               timestamp: new Date().toISOString(),
@@ -64,7 +53,7 @@ export default class Whoami extends Command {
             }
           }, null, 2))
         } else {
-          this.error(error.message)
+          this.error(error.toHumanString())
         }
 
         process.exit(1)
@@ -210,49 +199,15 @@ export default class Whoami extends Command {
 
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-
-      // Build suggestions based on error type
-      const suggestions: string[] = []
-
-      if (cliError.code === ErrorCode.UNAUTHORIZED) {
-        suggestions.push('Check NOTION_TOKEN: echo $NOTION_TOKEN')
-        suggestions.push('Verify token at: https://www.notion.so/my-integrations')
-        suggestions.push('Get new token: https://developers.notion.com/docs/create-a-notion-integration')
-      } else if (cliError.code === ErrorCode.RATE_LIMITED) {
-        suggestions.push('Wait a moment and try again')
-        suggestions.push('Rate limit will reset automatically')
-      } else {
-        suggestions.push('Check your internet connection')
-        suggestions.push('Verify Notion API status: https://status.notion.so')
-        suggestions.push('Try again with --no-cache flag')
-      }
+      const cliError = wrapNotionError(error, {
+        resourceType: 'user',
+        endpoint: 'users.me',
+      })
 
       if (flags.json) {
-        this.log(JSON.stringify({
-          success: false,
-          error: {
-            code: cliError.code,
-            message: cliError.message,
-            suggestions,
-            details: cliError.details,
-          },
-          metadata: {
-            timestamp: new Date().toISOString(),
-            command: 'whoami',
-            execution_time_ms: Date.now() - startTime,
-          }
-        }, null, 2))
+        this.log(JSON.stringify(cliError.toJSON(), null, 2))
       } else {
-        this.log('\nConnection Failed')
-        this.log('='.repeat(60))
-        this.log(`Error:       ${cliError.code}`)
-        this.log(`Message:     ${cliError.message}`)
-        this.log('\nSuggestions:')
-        suggestions.forEach(suggestion => {
-          this.log(`  - ${suggestion}`)
-        })
-        this.log('='.repeat(60))
+        this.error(cliError.toHumanString())
       }
 
       process.exit(1)

--- a/src/utils/notion-resolver.ts
+++ b/src/utils/notion-resolver.ts
@@ -16,7 +16,7 @@
  */
 
 import { extractNotionId, isNotionUrl } from './notion-url-parser'
-import { NotionCLIError, ErrorCode, wrapNotionError } from '../errors'
+import { NotionCLIError, NotionCLIErrorCode, wrapNotionError } from '../errors/enhanced-errors'
 import { loadCache } from './workspace-cache'
 import { search, retrieveDataSource } from '../notion'
 import { isFullPage } from '@notionhq/client'
@@ -58,8 +58,9 @@ export async function resolveNotionId(
 ): Promise<string> {
   if (!input || typeof input !== 'string') {
     throw new NotionCLIError(
-      ErrorCode.VALIDATION_ERROR,
-      `Invalid input: expected a ${type} name, ID, or URL`
+      NotionCLIErrorCode.VALIDATION_ERROR,
+      `Invalid input: expected a ${type} name, ID, or URL`,
+      []
     )
   }
 
@@ -76,10 +77,11 @@ export async function resolveNotionId(
       return extractedId
     } catch (error) {
       throw new NotionCLIError(
-        ErrorCode.VALIDATION_ERROR,
+        NotionCLIErrorCode.INVALID_URL,
         `Invalid Notion URL: ${trimmed}\n\n` +
         `Expected format: https://www.notion.so/{id}\n` +
         `Example: https://www.notion.so/1fb79d4c71bb8032b722c82305b63a00`,
+        [],
         { originalError: error }
       )
     }
@@ -105,12 +107,13 @@ export async function resolveNotionId(
 
   // Nothing found - throw helpful error
   throw new NotionCLIError(
-    ErrorCode.NOT_FOUND,
+    NotionCLIErrorCode.NOT_FOUND,
     `${type === 'database' ? 'Database' : 'Page'} "${input}" not found.\n\n` +
     `Try:\n` +
     `  1. Run 'notion-cli sync' to refresh your workspace index\n` +
     `  2. Use the full Notion URL instead\n` +
-    `  3. Check available databases with 'notion-cli list'`
+    `  3. Check available databases with 'notion-cli list'`,
+    []
   )
 }
 


### PR DESCRIPTION
Replaces stack traces with user-friendly error messages that include context and suggestions.

## Changes
- Context-rich errors with resource type, attempted ID, endpoint, user input
- Formatted error messages using `toHumanString()` with:
  - ❌ Error emoji and clear message
  - 💡 Actionable suggestions with example commands
  - 🔗 Links to relevant documentation
  - 🐛 Debug info when DEBUG mode enabled
- Better JSON parse errors with helpful syntax guidance
- Consistent error handling across all commands

## Example Improvement
**Before (stack trace):**
```
APIResponseError: path failed validation...
    at buildRequestError (/Users/.../notion-cli/node_modules/@notionhq/client/src/errors.ts:252:12)
    ...
```

**After (user-friendly):**
```
❌ Invalid page ID format: invalid-page-id
   Error Code: INVALID_ID_FORMAT

💡 Possible causes and fixes:
   1. Notion IDs are 32 hexadecimal characters (with or without dashes)
   2. Valid format: 1fb79d4c71bb8032b722c82305b63a00
   3. Try using the full Notion URL instead
      $ notion-cli page retrieve https://notion.so/your-url-here
```

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)