### PR TITLE
feat: Add context and suggestions to error messages

### DIFF
--- a/src/commands/block/append.ts
+++ b/src/commands/block/append.ts
@@ -7,7 +7,7 @@ import {
 import { getBlockPlainText, outputRawJson } from '../../helper'
 import { resolveNotionId } from '../../utils/notion-resolver'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class BlockAppend extends Command {
   static description = 'Append block children'
@@ -118,13 +118,11 @@ export default class BlockAppend extends Command {
       ux.table(res.results, columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'block',
+        attemptedId: flags['block-id'],
+        endpoint: 'blocks.children.append'
+      })
     }
   }
 }

--- a/src/commands/block/delete.ts
+++ b/src/commands/block/delete.ts
@@ -3,7 +3,7 @@ import * as notion from '../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class BlockDelete extends Command {
   static description = 'Delete a block'
@@ -81,13 +81,11 @@ export default class BlockDelete extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        endpoint: 'blocks.delete'
+      })
     }
   }
 }

--- a/src/commands/block/retrieve.ts
+++ b/src/commands/block/retrieve.ts
@@ -3,7 +3,7 @@ import * as notion from '../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class BlockRetrieve extends Command {
   static description = 'Retrieve a block'
@@ -81,13 +81,11 @@ export default class BlockRetrieve extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        endpoint: 'blocks.retrieve'
+      })
     }
   }
 }

--- a/src/commands/block/retrieve/children.ts
+++ b/src/commands/block/retrieve/children.ts
@@ -3,7 +3,7 @@ import * as notion from '../../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import { getBlockPlainText, outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { handleCliError } from '../../../errors'
 
 export default class BlockRetrieveChildren extends Command {
   static description = 'Retrieve block children'
@@ -84,13 +84,11 @@ export default class BlockRetrieveChildren extends Command {
       ux.table(res.results, columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        endpoint: 'blocks.children.list'
+      })
     }
   }
 }

--- a/src/commands/block/update.ts
+++ b/src/commands/block/update.ts
@@ -7,7 +7,7 @@ import {
 import { outputRawJson, getBlockPlainText } from '../../helper'
 import { resolveNotionId } from '../../utils/notion-resolver'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class BlockUpdate extends Command {
   static description = 'Update a block'
@@ -136,13 +136,11 @@ export default class BlockUpdate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'block',
+        attemptedId: args.block_id,
+        endpoint: 'blocks.update'
+      })
     }
   }
 }

--- a/src/commands/db/create.ts
+++ b/src/commands/db/create.ts
@@ -6,7 +6,7 @@ import {
 import * as notion from '../../notion'
 import { outputRawJson, getDbTitle } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { NotionCLIError, NotionCLIErrorCode, handleCliError } from '../../errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbCreate extends Command {
@@ -118,13 +118,10 @@ export default class DbCreate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'database',
+        endpoint: 'databases.create'
+      })
     }
   }
 }

--- a/src/commands/db/retrieve.ts
+++ b/src/commands/db/retrieve.ts
@@ -10,7 +10,7 @@ import {
   showRawFlagHint
 } from '../../helper'
 import { AutomationFlags, OutputFormatFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbRetrieve extends Command {
@@ -131,13 +131,11 @@ export default class DbRetrieve extends Command {
       showRawFlagHint(1, res)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'database',
+        attemptedId: args.database_id,
+        endpoint: 'dataSources.retrieve'
+      })
     }
   }
 }

--- a/src/commands/db/schema.ts
+++ b/src/commands/db/schema.ts
@@ -13,7 +13,7 @@ import {
   groupExamplesByWritability,
   PropertyExample,
 } from '../../utils/schema-examples'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbSchema extends Command {
@@ -206,15 +206,11 @@ export default class DbSchema extends Command {
       this.outputTable(schema)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-
-      if (flags.json || flags.output === 'json') {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-
-      process.exit(1)
+      handleCliError(error, flags.json || flags.output === 'json', {
+        resourceType: 'database',
+        attemptedId: args.database_id,
+        endpoint: 'dataSources.retrieve'
+      })
     }
   }
 

--- a/src/commands/db/update.ts
+++ b/src/commands/db/update.ts
@@ -6,7 +6,7 @@ import {
 import * as notion from '../../notion'
 import { outputRawJson, getDataSourceTitle } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { NotionCLIError, wrapNotionError } from '../../errors'
+import { NotionCLIError, NotionCLIErrorCode, handleCliError } from '../../errors'
 import { resolveNotionId } from '../../utils/notion-resolver'
 
 export default class DbUpdate extends Command {
@@ -109,13 +109,11 @@ export default class DbUpdate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'database',
+        attemptedId: args.database_id,
+        endpoint: 'dataSources.update'
+      })
     }
   }
 }

--- a/src/commands/page/create.ts
+++ b/src/commands/page/create.ts
@@ -11,7 +11,7 @@ import {
 import { getPageTitle, outputRawJson } from '../../helper'
 import { resolveNotionId } from '../../utils/notion-resolver'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 import { expandSimpleProperties } from '../../utils/property-expander'
 
 export default class PageCreate extends Command {
@@ -231,13 +231,10 @@ export default class PageCreate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'page',
+        endpoint: 'pages.create'
+      })
     }
   }
 }

--- a/src/commands/page/retrieve.ts
+++ b/src/commands/page/retrieve.ts
@@ -12,7 +12,7 @@ import {
 import { NotionToMarkdown } from 'notion-to-md'
 import { AutomationFlags, OutputFormatFlags } from '../../base-flags'
 import { resolveNotionId } from '../../utils/notion-resolver'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class PageRetrieve extends Command {
   static description = 'Retrieve a page'
@@ -154,13 +154,11 @@ export default class PageRetrieve extends Command {
       // Show hint after table output to make -r flag discoverable
       showRawFlagHint(1, res)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'page',
+        attemptedId: args.page_id,
+        endpoint: 'pages.retrieve'
+      })
     }
   }
 }

--- a/src/commands/page/retrieve/property_item.ts
+++ b/src/commands/page/retrieve/property_item.ts
@@ -2,7 +2,7 @@ import { Args, Command, Flags } from '@oclif/core'
 import * as notion from '../../../notion'
 import { outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { handleCliError } from '../../../errors'
 
 export default class PageRetrievePropertyItem extends Command {
   static description = 'Retrieve a page property item'
@@ -58,13 +58,11 @@ export default class PageRetrievePropertyItem extends Command {
       outputRawJson(res)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'page',
+        attemptedId: args.page_id,
+        endpoint: 'pages.properties.retrieve'
+      })
     }
   }
 }

--- a/src/commands/page/update.ts
+++ b/src/commands/page/update.ts
@@ -4,7 +4,7 @@ import { UpdatePageParameters, PageObjectResponse } from '@notionhq/client/build
 import { getPageTitle, outputRawJson } from '../../helper'
 import { resolveNotionId } from '../../utils/notion-resolver'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 import { expandSimpleProperties } from '../../utils/property-expander'
 
 export default class PageUpdate extends Command {
@@ -181,13 +181,11 @@ export default class PageUpdate extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'page',
+        attemptedId: args.page_id,
+        endpoint: 'pages.update'
+      })
     }
   }
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,7 +18,7 @@ import {
   showRawFlagHint
 } from '../helper'
 import { AutomationFlags, OutputFormatFlags } from '../base-flags'
-import { wrapNotionError } from '../errors'
+import { handleCliError } from '../errors'
 
 export default class Search extends Command {
   static description = 'Search by title'
@@ -232,13 +232,9 @@ export default class Search extends Command {
         showRawFlagHint(res.results.length, res.results[0])
       }
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        endpoint: 'search'
+      })
     }
   }
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -11,7 +11,7 @@ import {
 } from '../utils/workspace-cache'
 import { getDataSourceTitle } from '../helper'
 import { AutomationFlags } from '../base-flags'
-import { NotionCLIError, wrapNotionError } from '../errors'
+import { NotionCLIError, NotionCLIErrorCode, handleCliError } from '../errors'
 import { DataSourceObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as os from 'os'
 import * as path from 'path'
@@ -146,14 +146,12 @@ export default class Sync extends Command {
 
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
+      if (!flags.json) {
         ux.action.stop('failed')
-        this.error(cliError.message)
       }
+      handleCliError(error, flags.json, {
+        endpoint: 'search'
+      })
 
       process.exit(1)
     }

--- a/src/commands/user/list.ts
+++ b/src/commands/user/list.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../notion'
 import { outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class UserList extends Command {
   static description = 'List all users'
@@ -82,13 +82,9 @@ export default class UserList extends Command {
       ux.table(res.results, columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        endpoint: 'users.list'
+      })
     }
   }
 }

--- a/src/commands/user/retrieve.ts
+++ b/src/commands/user/retrieve.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../notion'
 import { outputRawJson } from '../../helper'
 import { AutomationFlags } from '../../base-flags'
-import { wrapNotionError } from '../../errors'
+import { handleCliError } from '../../errors'
 
 export default class UserRetrieve extends Command {
   static description = 'Retrieve a user'
@@ -86,13 +86,11 @@ export default class UserRetrieve extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'user',
+        attemptedId: args.user_id,
+        endpoint: 'users.retrieve'
+      })
     }
   }
 }

--- a/src/commands/user/retrieve/bot.ts
+++ b/src/commands/user/retrieve/bot.ts
@@ -3,7 +3,7 @@ import { UserObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import * as notion from '../../../notion'
 import { outputRawJson } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
-import { wrapNotionError } from '../../../errors'
+import { handleCliError } from '../../../errors'
 
 export default class UserRetrieveBot extends Command {
   static description = 'Retrieve a bot user'
@@ -84,13 +84,10 @@ export default class UserRetrieveBot extends Command {
       ux.table([res], columns, options)
       process.exit(0)
     } catch (error) {
-      const cliError = wrapNotionError(error)
-      if (flags.json) {
-        this.log(JSON.stringify(cliError.toJSON(), null, 2))
-      } else {
-        this.error(cliError.message)
-      }
-      process.exit(1)
+      handleCliError(error, flags.json, {
+        resourceType: 'user',
+        endpoint: 'users.retrieve.bot'
+      })
     }
   }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-// Export enhanced error system
+// Export enhanced error system (primary exports)
 export {
   // Error Class
   NotionCLIError,
@@ -35,11 +35,3 @@ export {
   ErrorSuggestion,
   ErrorContext,
 } from './enhanced-errors'
-
-// Re-export legacy error system for backward compatibility
-// TODO: Remove after migration is complete
-export {
-  ErrorCode as LegacyErrorCode,
-  NotionCLIError as LegacyNotionCLIError,
-  wrapNotionError as legacyWrapNotionError,
-} from '../errors'


### PR DESCRIPTION
Adds helpful context and actionable suggestions to all error messages.

## Changes
- All errors include context: resource type, attempted ID, endpoint, status code
- Actionable suggestions with example commands
- Structured JSON errors for automation with recovery hints
- Consistent error format across all commands
- Clear explanations of what went wrong and how to fix it

## Benefits
✅ Faster debugging - Users see exactly what went wrong with context  
✅ Actionable fixes - Specific suggestions with example commands  
✅ Better for AI agents - Structured JSON errors enable automated recovery  
✅ Consistent - All commands use the same error format  
✅ Learning tool - Users understand Notion API concepts through clear errors

## Example
**Before:**
```
Error: object_not_found
```

**After (Human Mode):**
```
❌ Page not found
   Error Code: OBJECT_NOT_FOUND

💡 Possible causes and fixes:
   1. The ID may be incorrect - verify it in Notion
   2. The integration may not have access
   3. The page may have been deleted
   4. Try using the full Notion URL instead
      $ notion-cli page retrieve https://notion.so/your-url
```

**After (JSON Mode for Automation):**
```json
{
  "success": false,
  "error": {
    "code": "OBJECT_NOT_FOUND",
    "message": "Page not found",
    "suggestions": [
      {"description": "The ID may be incorrect - verify it in Notion"},
      {"description": "The integration may not have access"}
    ],
    "context": {
      "resourceType": "page",
      "attemptedId": "abc123...",
      "endpoint": "pages.retrieve",
      "statusCode": 404
    }
  }
}
```

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)