### PR TITLE
feat: Fix database discovery workflow with enriched child_database blocks

### DIFF
--- a/src/commands/block/retrieve/children.ts
+++ b/src/commands/block/retrieve/children.ts
@@ -1,12 +1,12 @@
 import { Args, Command, Flags, ux } from '@oclif/core'
 import * as notion from '../../../notion'
 import { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
-import { getBlockPlainText, outputRawJson, stripMetadata } from '../../../helper'
+import { getBlockPlainText, outputRawJson, stripMetadata, enrichChildDatabaseBlock, getChildDatabasesWithIds } from '../../../helper'
 import { AutomationFlags } from '../../../base-flags'
 import { wrapNotionError } from '../../../errors'
 
 export default class BlockRetrieveChildren extends Command {
-  static description = 'Retrieve block children'
+  static description = 'Retrieve block children (supports database discovery via --show-databases)'
 
   static aliases: string[] = ['block:r:c']
 
@@ -23,6 +23,14 @@ export default class BlockRetrieveChildren extends Command {
       description: 'Retrieve block children and output JSON for automation',
       command: `$ notion-cli block retrieve:children BLOCK_ID --json`,
     },
+    {
+      description: 'Discover databases on a page with queryable IDs',
+      command: `$ notion-cli block retrieve:children PAGE_ID --show-databases`,
+    },
+    {
+      description: 'Get databases as JSON for automation',
+      command: `$ notion-cli block retrieve:children PAGE_ID --show-databases --json`,
+    },
   ]
 
   static args = {
@@ -37,6 +45,11 @@ export default class BlockRetrieveChildren extends Command {
       char: 'r',
       description: 'output raw json',
     }),
+    'show-databases': Flags.boolean({
+      char: 'd',
+      description: 'show only child databases with their queryable IDs (data_source_id)',
+      default: false,
+    }),
     ...ux.table.flags(),
     ...AutomationFlags,
   }
@@ -47,6 +60,76 @@ export default class BlockRetrieveChildren extends Command {
     try {
       // TODO: Add support start_cursor, page_size
       let res = await notion.retrieveBlockChildren(args.block_id)
+
+      // Handle --show-databases flag: filter and enrich child_database blocks
+      if (flags['show-databases']) {
+        const databases = await getChildDatabasesWithIds(res.results as BlockObjectResponse[])
+
+        // Handle JSON output for automation
+        if (flags.json) {
+          this.log(JSON.stringify({
+            success: true,
+            data: databases,
+            timestamp: new Date().toISOString()
+          }, null, 2))
+          process.exit(0)
+          return
+        }
+
+        // Handle raw JSON output
+        if (flags.raw) {
+          outputRawJson(databases)
+          process.exit(0)
+          return
+        }
+
+        // Display databases in table format
+        const columns = {
+          block_id: {
+            header: 'Block ID',
+          },
+          title: {
+            header: 'Title',
+          },
+          data_source_id: {
+            header: 'Data Source ID',
+          },
+          database_id: {
+            header: 'Database ID',
+          },
+        }
+
+        const options = {
+          printLine: this.log.bind(this),
+          ...flags,
+        }
+
+        ux.table(databases, columns, options)
+
+        // Show helpful tip
+        if (databases.length > 0) {
+          this.log('\nTip: Use the data_source_id to query databases:')
+          this.log(`  notion-cli db query <data_source_id>`)
+        } else {
+          this.log('\nNo child databases found on this page.')
+        }
+
+        process.exit(0)
+        return
+      }
+
+      // Auto-enrich child_database blocks for JSON/raw output
+      if (flags.json || flags.raw) {
+        const enrichedResults = await Promise.all(
+          (res.results as BlockObjectResponse[]).map(async (block) => {
+            if (block.type === 'child_database') {
+              return await enrichChildDatabaseBlock(block)
+            }
+            return block
+          })
+        )
+        res.results = enrichedResults
+      }
 
       // Apply minimal flag to strip metadata
       if (flags.minimal) {


### PR DESCRIPTION
Fixes the broken database discovery workflow by enriching child_database blocks with queryable IDs.

## Changes
- Added `enrichChildDatabaseBlock()` helper in `src/helper.ts`
- Added `getChildDatabasesWithIds()` helper for database discovery
- New `--show-databases` / `-d` flag in `block retrieve children` command
- Auto-enriches child_database blocks with `data_source_id` and `database_id`
- Updated command description and added helpful usage examples

## How It Works
Attempts to use the child_database block ID itself as a data_source_id (which often works in Notion's API). When successful, adds `data_source_id` and `database_id` fields to make it queryable.

## Workflow Now Fixed

**Before (broken):**
```bash
notion-cli block retrieve children PAGE_ID -r
# Returns: child_database with title but NO ID - dead end ❌
```

**After (fixed):**
```bash
# Option 1: Discover databases
notion-cli block retrieve children PAGE_ID --show-databases
# Shows: block_id, title, data_source_id, database_id ✅

# Option 2: Get enriched blocks
notion-cli block retrieve children PAGE_ID -r
# Returns: child_database blocks WITH data_source_id field ✅

# Now you can query:
notion-cli db query <data_source_id>
```

## Example Usage
```bash
# Discover databases on a page
notion-cli block retrieve children PAGE_ID --show-databases

# Get databases as JSON for automation
notion-cli block retrieve children PAGE_ID --show-databases --json

# Regular retrieval with enriched blocks
notion-cli block retrieve children PAGE_ID -r
```

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)