### PR TITLE
fix: Update imports to use enhanced error system

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -7,7 +7,7 @@
 
 import { Command, Flags, Interfaces } from '@oclif/core'
 import { EnvelopeFormatter, ExitCode, OutputFlags } from './envelope'
-import { wrapNotionError, NotionCLIError } from './errors'
+import { wrapNotionError, NotionCLIError, NotionCLIErrorCode } from './errors/index'
 
 /**
  * Base command configuration

--- a/src/envelope.ts
+++ b/src/envelope.ts
@@ -8,7 +8,7 @@
  * - Proper stdout/stderr separation
  */
 
-import { ErrorCode, NotionCLIError } from './errors'
+import { NotionCLIErrorCode, NotionCLIError } from './errors/index'
 
 /**
  * Standard metadata included in all envelopes
@@ -39,7 +39,7 @@ export interface SuccessEnvelope<T = any> {
  */
 export interface ErrorDetails {
   /** Semantic error code (e.g., "DATABASE_NOT_FOUND", "RATE_LIMITED") */
-  code: ErrorCode | string
+  code: NotionCLIErrorCode | string
   /** Human-readable error message */
   message: string
   /** Additional context about the error */
@@ -92,10 +92,10 @@ export interface OutputFlags {
 /**
  * Maps error codes to appropriate exit codes
  */
-function getExitCodeForError(errorCode: ErrorCode | string): ExitCode {
+function getExitCodeForError(errorCode: NotionCLIErrorCode | string): ExitCode {
   // CLI/validation errors
   const cliErrors = [
-    ErrorCode.VALIDATION_ERROR,
+    NotionCLIErrorCode.VALIDATION_ERROR,
     'VALIDATION_ERROR',
     'CLI_ERROR',
     'CONFIG_ERROR',
@@ -113,24 +113,24 @@ function getExitCodeForError(errorCode: ErrorCode | string): ExitCode {
 /**
  * Suggestion generator based on error codes
  */
-function generateSuggestions(errorCode: ErrorCode | string): string[] {
+function generateSuggestions(errorCode: NotionCLIErrorCode | string): string[] {
   const suggestions: string[] = []
 
   switch (errorCode) {
-    case ErrorCode.UNAUTHORIZED:
+    case NotionCLIErrorCode.UNAUTHORIZED:
       suggestions.push('Verify your NOTION_TOKEN is set correctly')
       suggestions.push('Check token at: https://www.notion.so/my-integrations')
       break
-    case ErrorCode.NOT_FOUND:
+    case NotionCLIErrorCode.NOT_FOUND:
       suggestions.push('Verify the resource ID is correct')
       suggestions.push('Ensure your integration has access to the resource')
       suggestions.push('Try running: notion-cli sync')
       break
-    case ErrorCode.RATE_LIMITED:
+    case NotionCLIErrorCode.RATE_LIMITED:
       suggestions.push('Wait and retry - the CLI will auto-retry with backoff')
       suggestions.push('Reduce request frequency if this persists')
       break
-    case ErrorCode.VALIDATION_ERROR:
+    case NotionCLIErrorCode.VALIDATION_ERROR:
       suggestions.push('Check command syntax: notion-cli [command] --help')
       suggestions.push('Verify all required arguments are provided')
       break

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,14 @@
+/**
+ * @deprecated This file is deprecated. Use the enhanced error system instead:
+ * import { NotionCLIError, NotionCLIErrorCode, NotionCLIErrorFactory, wrapNotionError } from './errors/index'
+ *
+ * The new error system provides:
+ * - More detailed error codes
+ * - Context-rich error messages
+ * - Actionable suggestions with commands
+ * - Better AI-friendly formatting
+ */
+
 export enum ErrorCode {
   RATE_LIMITED = 'RATE_LIMITED',
   NOT_FOUND = 'NOT_FOUND',


### PR DESCRIPTION
Fixes import confusion where some files were importing from the old legacy error system instead of the new enhanced system.

## Root Cause
Two error systems existed:
- ✅ **New (enhanced)**: `src/errors/enhanced-errors.ts` → exported via `src/errors/index.ts`
- ⚠️ **Old (legacy)**: `src/errors.ts` (deprecated)

Files `src/base-command.ts` and `src/envelope.ts` were importing from the old system.

## Changes
- Updated `src/base-command.ts` to import from `./errors/index`
- Updated `src/envelope.ts` to import from `./errors/index`
- Replaced all `ErrorCode` references with `NotionCLIErrorCode`
- Added deprecation notice to legacy `src/errors.ts`

## Verification
The enhanced error system was already fully implemented with all required features:
- ✅ `NotionCLIError` class with `toHumanString()` and `toJSON()`
- ✅ `NotionCLIErrorFactory` with all factory methods
- ✅ `wrapNotionError()` function for API error mapping
- ✅ All exports properly configured

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)