### PR TITLE
fix: Update NotionCLIError constructor signatures in commands

### DIFF
--- a/src/commands/batch/retrieve.ts
+++ b/src/commands/batch/retrieve.ts
@@ -10,6 +10,7 @@ import {
 import { AutomationFlags, OutputFormatFlags } from '../../base-flags'
 import {
   NotionCLIError,
+  NotionCLIErrorCode,
   wrapNotionError
 } from '../../errors'
 import { PageObjectResponse, BlockObjectResponse, GetDataSourceResponse } from '@notionhq/client/build/src/api-endpoints'
@@ -129,7 +130,12 @@ export default class BatchRetrieve extends Command {
           data = await notion.retrieveDataSource(id)
           break
         default:
-          throw new NotionCLIError(`Invalid resource type: ${type}`, 'VALIDATION_ERROR')
+          throw new NotionCLIError(
+            NotionCLIErrorCode.VALIDATION_ERROR,
+            `Invalid resource type: ${type}`,
+            [],
+            { userInput: type, resourceType: type as any }
+          )
       }
 
       return {
@@ -174,8 +180,18 @@ export default class BatchRetrieve extends Command {
 
       if (ids.length === 0) {
         throw new NotionCLIError(
+          NotionCLIErrorCode.VALIDATION_ERROR,
           'No IDs provided. Use --ids flag, positional argument, or pipe IDs via stdin',
-          'VALIDATION_ERROR'
+          [
+            {
+              description: 'Provide IDs via --ids flag',
+              command: 'notion-cli batch retrieve --ids ID1,ID2,ID3'
+            },
+            {
+              description: 'Or pipe IDs from a file',
+              command: 'cat ids.txt | notion-cli batch retrieve'
+            }
+          ]
         )
       }
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -21,6 +21,7 @@ import {
 import { AutomationFlags, OutputFormatFlags } from '../base-flags'
 import {
   NotionCLIError,
+  NotionCLIErrorCode,
   NotionCLIErrorFactory,
   wrapNotionError
 } from '../errors'
@@ -169,26 +170,34 @@ export default class Search extends Command {
       // Validate date filters
       if (flags['created-after'] && !dayjs(flags['created-after']).isValid()) {
         throw new NotionCLIError(
-          'VALIDATION_ERROR' as any,
-          `Invalid date format for --created-after: ${flags['created-after']}. Use ISO 8601 format (YYYY-MM-DD).`
+          NotionCLIErrorCode.VALIDATION_ERROR,
+          `Invalid date format for --created-after: ${flags['created-after']}. Use ISO 8601 format (YYYY-MM-DD).`,
+          [],
+          { userInput: flags['created-after'] }
         )
       }
       if (flags['created-before'] && !dayjs(flags['created-before']).isValid()) {
         throw new NotionCLIError(
-          'VALIDATION_ERROR' as any,
-          `Invalid date format for --created-before: ${flags['created-before']}. Use ISO 8601 format (YYYY-MM-DD).`
+          NotionCLIErrorCode.VALIDATION_ERROR,
+          `Invalid date format for --created-before: ${flags['created-before']}. Use ISO 8601 format (YYYY-MM-DD).`,
+          [],
+          { userInput: flags['created-before'] }
         )
       }
       if (flags['edited-after'] && !dayjs(flags['edited-after']).isValid()) {
         throw new NotionCLIError(
-          'VALIDATION_ERROR' as any,
-          `Invalid date format for --edited-after: ${flags['edited-after']}. Use ISO 8601 format (YYYY-MM-DD).`
+          NotionCLIErrorCode.VALIDATION_ERROR,
+          `Invalid date format for --edited-after: ${flags['edited-after']}. Use ISO 8601 format (YYYY-MM-DD).`,
+          [],
+          { userInput: flags['edited-after'] }
         )
       }
       if (flags['edited-before'] && !dayjs(flags['edited-before']).isValid()) {
         throw new NotionCLIError(
-          'VALIDATION_ERROR' as any,
-          `Invalid date format for --edited-before: ${flags['edited-before']}. Use ISO 8601 format (YYYY-MM-DD).`
+          NotionCLIErrorCode.VALIDATION_ERROR,
+          `Invalid date format for --edited-before: ${flags['edited-before']}. Use ISO 8601 format (YYYY-MM-DD).`,
+          [],
+          { userInput: flags['edited-before'] }
         )
       }
 


### PR DESCRIPTION
Fixes TypeScript errors where commands were using incorrect constructor signatures for the `NotionCLIError` class.

## Root Cause
The enhanced error system was correctly implemented with a 4-parameter constructor, but some commands were:
1. Using wrong constructor signatures (2 params instead of 4)
2. Referencing legacy `ErrorCode` enum instead of `NotionCLIErrorCode`

## Constructor Signature
```typescript
new NotionCLIError(
  code: NotionCLIErrorCode,
  message: string,
  suggestions: ErrorSuggestion[],
  context: ErrorContext
)
```

## Changes

**`whoami.ts`:**
- Replaced manual `NotionCLIError` construction with `NotionCLIErrorFactory.tokenMissing()`
- Updated error handling to use `error.toJSON()` and `error.toHumanString()`

**`search.ts`:**
- Added `NotionCLIErrorCode` import
- Fixed 4 date validation errors to use correct 4-parameter constructor

**`batch/retrieve.ts`:**
- Added `NotionCLIErrorCode` import
- Fixed invalid resource type error with proper constructor
- Fixed "No IDs provided" error with helpful suggestions

## Errors Fixed
All `Expected 1 arguments, but got 2` and `Cannot find name 'ErrorCode'` errors resolved ✅

Fixes #36

🤖 Generated with [Claude Code](https://claude.ai/code)