### PR TITLE
fix: Update envelope.ts to use new NotionCLIError properties

### DIFF
--- a/src/envelope.ts
+++ b/src/envelope.ts
@@ -204,9 +204,9 @@ export class EnvelopeFormatter {
       errorDetails = {
         code: error.code,
         message: error.message,
-        details: { ...error.details, ...additionalContext },
-        suggestions: generateSuggestions(error.code),
-        notionError: error.notionError,
+        details: { ...error.context, ...additionalContext },
+        suggestions: error.suggestions.map(s => s.description),
+        notionError: error.context.originalError,
       }
     }
     // Handle standard Error


### PR DESCRIPTION
Fixes #42

Updates `src/envelope.ts` to use the new enhanced error system properties:

- Replace `error.details` with `error.context`
- Replace `error.notionError` with `error.context.originalError`
- Use `error.suggestions.map(s => s.description)` to extract suggestion descriptions

This resolves TypeScript compilation errors on lines 207 and 209.