### PR TITLE
fix: Replace non-existent NotionCLIErrorFactory.apiError() in block/update.ts

### DIFF
--- a/src/commands/block/update.ts
+++ b/src/commands/block/update.ts
@@ -10,6 +10,7 @@ import { resolveNotionId } from '../../utils/notion-resolver'
 import { AutomationFlags } from '../../base-flags'
 import {
   NotionCLIError,
+  NotionCLIErrorCode,
   NotionCLIErrorFactory,
   wrapNotionError
 } from '../../errors'
@@ -185,7 +186,7 @@ export default class BlockUpdate extends Command {
         // Ensure we have a full block response
         if (!isFullBlock(blockResponse)) {
           throw new NotionCLIError(
-            NotionCLIErrorFactory.apiError('block', blockId).code,
+            NotionCLIErrorCode.API_ERROR,
             'Received partial block response. Cannot determine block type for color update.',
             [],
             { attemptedId: blockId }


### PR DESCRIPTION
Fixes #48

Replaces the non-existent `NotionCLIErrorFactory.apiError()` method call with a direct `new NotionCLIError()` instantiation using appropriate error code and message.

**This is the LAST compilation error!** 🎉

After this merge, the project should compile successfully with 0 errors.