### PR TITLE
Fix data source search and sync handling

### DIFF
--- a/internal/cli/commands/config_cmd.go
+++ b/internal/cli/commands/config_cmd.go
@@ -83,10 +83,7 @@ func runConfigSetToken(cmd *cobra.Command, args []string) error {
 			token = strings.TrimSpace(scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			return handleError(cmd, &clierrors.NotionCLIError{
-				Code:    clierrors.CodeInternalError,
-				Message: fmt.Sprintf("Failed to read stdin: %s", err),
-			})
+			return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to read stdin", err))
 		}
 		if token == "" {
 			return handleError(cmd, &clierrors.NotionCLIError{
@@ -102,18 +99,12 @@ func runConfigSetToken(cmd *cobra.Command, args []string) error {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return handleError(cmd, &clierrors.NotionCLIError{
-			Code:    clierrors.CodeInternalError,
-			Message: fmt.Sprintf("Failed to load config: %s", err),
-		})
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to load config", err))
 	}
 
 	cfg.Token = token
 	if err := config.SaveConfig(cfg); err != nil {
-		return handleError(cmd, &clierrors.NotionCLIError{
-			Code:    clierrors.CodeInternalError,
-			Message: fmt.Sprintf("Failed to save config: %s", err),
-		})
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to save config", err))
 	}
 
 	p := output.NewPrinter(outputFormat(cmd))
@@ -187,10 +178,7 @@ func runConfigList(cmd *cobra.Command, args []string) error {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return handleError(cmd, &clierrors.NotionCLIError{
-			Code:    clierrors.CodeInternalError,
-			Message: fmt.Sprintf("Failed to load config: %s", err),
-		})
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to load config", err))
 	}
 
 	// Mask token.

--- a/internal/cli/commands/db.go
+++ b/internal/cli/commands/db.go
@@ -104,6 +104,22 @@ func outputFormat(cmd *cobra.Command) output.Format {
 	return output.FormatTable
 }
 
+// outputFormatExplicit reports whether the user explicitly requested a
+// non-default output mode.
+func outputFormatExplicit(cmd *cobra.Command) bool {
+	if flag := cmd.Flags().Lookup("output"); flag != nil {
+		if value, _ := cmd.Flags().GetString("output"); flag.Changed || value != "" {
+			return true
+		}
+	}
+	for _, name := range []string{"json", "compact-json", "raw", "csv", "markdown", "pretty"} {
+		if flag := cmd.Flags().Lookup(name); flag != nil && flag.Changed {
+			return true
+		}
+	}
+	return false
+}
+
 // validateOutputFlag checks the --output flag value upfront and returns an error
 // for invalid values. Call this at the start of RunE handlers.
 func validateOutputFlag(cmd *cobra.Command) error {
@@ -131,7 +147,7 @@ func handleError(cmd *cobra.Command, err error) error {
 
 	// Check for NotionCLIError first.
 	if cliErr, ok := err.(*clierrors.NotionCLIError); ok {
-		p.PrintError(cliErr.Code, cliErr.Message, cliErr.Details, cliErr.Suggestions)
+		p.PrintError(cliErr.Code, cliErr.DisplayMessage(), cliErr.Details, cliErr.Suggestions)
 		return err
 	}
 

--- a/internal/cli/commands/markdown.go
+++ b/internal/cli/commands/markdown.go
@@ -90,10 +90,7 @@ func runMarkdownGet(cmd *cobra.Command, args []string) error {
 	filePath, _ := cmd.Flags().GetString("file")
 	if filePath != "" {
 		if err := os.WriteFile(filePath, []byte(md), 0o644); err != nil {
-			return handleError(cmd, &clierrors.NotionCLIError{
-				Code:    clierrors.CodeInternalError,
-				Message: fmt.Sprintf("Cannot write file %q: %s", filePath, err),
-			})
+			return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, fmt.Sprintf("Cannot write file %q", filePath), err))
 		}
 		return nil
 	}
@@ -108,15 +105,7 @@ func runMarkdownGet(cmd *cobra.Command, args []string) error {
 // isStructuredOutputRequested reports whether the caller explicitly asked for
 // a structured output format. When false, `markdown get` prints raw markdown.
 func isStructuredOutputRequested(cmd *cobra.Command) bool {
-	if v, _ := cmd.Flags().GetString("output"); v != "" {
-		return true
-	}
-	for _, name := range []string{"json", "compact-json", "raw", "csv", "markdown", "pretty"} {
-		if cmd.Flags().Changed(name) {
-			return true
-		}
-	}
-	return false
+	return outputFormatExplicit(cmd)
 }
 
 // --- markdown set ---

--- a/internal/cli/commands/search.go
+++ b/internal/cli/commands/search.go
@@ -28,7 +28,7 @@ func newSearchCmd() *cobra.Command {
 
 	cmd.Flags().StringP("query", "q", "", "Search query text")
 	cmd.Flags().StringP("sort-direction", "d", "desc", "Sort direction (asc or desc)")
-	cmd.Flags().StringP("property", "p", "", "Filter by object type (database or page)")
+	cmd.Flags().StringP("property", "p", "", "Filter by object type (data_source, database, or page)")
 	cmd.Flags().StringP("start-cursor", "c", "", "Pagination cursor")
 	cmd.Flags().IntP("page-size", "s", 5, "Number of results per page")
 	cmd.Flags().String("database", "", "Filter results by database ID")
@@ -71,9 +71,9 @@ func runSearch(cmd *cobra.Command, _ []string) error {
 
 	if prop, _ := cmd.Flags().GetString("property"); prop != "" {
 		switch strings.ToLower(prop) {
-		case "database", "databases", "db":
+		case "data_source", "data-source", "datasource", "database", "databases", "db":
 			body["filter"] = map[string]any{
-				"value":    "database",
+				"value":    "data_source",
 				"property": "object",
 			}
 		case "page", "pages":
@@ -84,9 +84,10 @@ func runSearch(cmd *cobra.Command, _ []string) error {
 		default:
 			return handleError(cmd, &clierrors.NotionCLIError{
 				Code:    clierrors.CodeInvalidRequest,
-				Message: fmt.Sprintf("Invalid --property value %q: must be 'database' or 'page'", prop),
+				Message: fmt.Sprintf("Invalid --property value %q: must be 'data_source', 'database', or 'page'", prop),
 				Suggestions: []string{
-					"Use --property database to filter for databases",
+					"Use --property data_source to filter for data sources",
+					"Use --property database as a compatibility alias",
 					"Use --property page to filter for pages",
 				},
 			})

--- a/internal/cli/commands/search_test.go
+++ b/internal/cli/commands/search_test.go
@@ -137,8 +137,8 @@ func TestClientSideFilter_EditedBefore(t *testing.T) {
 func TestClientSideFilter_MultipleFilters(t *testing.T) {
 	created := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	items := []any{
-		makeItem("db-a", created, ""),          // passes both
-		makeItem("db-b", created, ""),          // fails dbFilter
+		makeItem("db-a", created, ""),                // passes both
+		makeItem("db-b", created, ""),                // fails dbFilter
 		makeItem("db-a", "2023-01-01T00:00:00Z", ""), // fails createdAfter
 	}
 	got := clientSideFilter(items, "db-a", "2024-01-01", "", "", "")
@@ -272,6 +272,33 @@ func TestSearchCmd_PropertyPageFilter(t *testing.T) {
 	}
 	if filter["value"] != "page" {
 		t.Errorf("filter.value = %v, want page", filter["value"])
+	}
+	if filter["property"] != "object" {
+		t.Errorf("filter.property = %v, want object", filter["property"])
+	}
+}
+
+func TestSearchCmd_PropertyDatabaseFilterUsesDataSource(t *testing.T) {
+	var capturedBody map[string]any
+	_, cleanup := testSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"results":[],"has_more":false}`))
+	})
+	defer cleanup()
+
+	_, _, err := runSearchRoot(t, "search", "--property", "database")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filter, ok := capturedBody["filter"].(map[string]any)
+	if !ok {
+		t.Fatal("filter field missing from request body")
+	}
+	if filter["value"] != "data_source" {
+		t.Errorf("filter.value = %v, want data_source", filter["value"])
 	}
 	if filter["property"] != "object" {
 		t.Errorf("filter.property = %v, want object", filter["property"])

--- a/internal/cli/commands/sync.go
+++ b/internal/cli/commands/sync.go
@@ -43,10 +43,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 
 	wc := cache.NewWorkspaceCache()
 	if err := wc.Load(); err != nil {
-		return handleError(cmd, &clierrors.NotionCLIError{
-			Code:    clierrors.CodeInternalError,
-			Message: fmt.Sprintf("Failed to load workspace cache: %s", err),
-		})
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to load workspace cache", err))
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
@@ -77,7 +74,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 
 		body := map[string]any{
 			"filter": map[string]any{
-				"value":    "database",
+				"value":    "data_source",
 				"property": "object",
 			},
 			"page_size": 100,
@@ -93,62 +90,16 @@ func runSync(cmd *cobra.Command, _ []string) error {
 
 		results, _ := result["results"].([]any)
 		for _, r := range results {
-			db, ok := r.(map[string]any)
+			resultMap, ok := r.(map[string]any)
 			if !ok {
 				continue
 			}
-
-			entry := cache.DatabaseEntry{
-				ID: fmt.Sprintf("%v", db["id"]),
+			entry, dataSources, ok := cacheEntriesFromSearchResult(resultMap)
+			if !ok {
+				continue
 			}
-
-			// Extract title.
-			if titleArr, ok := db["title"].([]any); ok {
-				var parts []string
-				for _, t := range titleArr {
-					if tm, ok := t.(map[string]any); ok {
-						if pt, ok := tm["plain_text"].(string); ok {
-							parts = append(parts, pt)
-						}
-					}
-				}
-				entry.Title = strings.Join(parts, "")
-			}
-
-			if url, ok := db["url"].(string); ok {
-				entry.URL = url
-			}
-
-			if let, ok := db["last_edited_time"].(string); ok {
-				if t, err := time.Parse(time.RFC3339, let); err == nil {
-					entry.LastEdited = t
-				}
-			}
-
-			// Generate aliases from title.
-			entry.Aliases = generateAliases(entry.Title)
-
 			allDatabases = append(allDatabases, entry)
-
-			// Extract embedded data_sources if present.
-			if dsArr, ok := db["data_sources"].([]any); ok {
-				for _, rawDS := range dsArr {
-					dsMap, ok := rawDS.(map[string]any)
-					if !ok {
-						continue
-					}
-					dsEntry := cache.DataSourceEntry{
-						ID:         fmt.Sprintf("%v", dsMap["id"]),
-						DatabaseID: entry.ID,
-						Title:      entry.Title,
-						URL:        entry.URL,
-						LastEdited: entry.LastEdited,
-					}
-					if dsEntry.ID != "" && dsEntry.ID != "<nil>" {
-						allDataSources = append(allDataSources, dsEntry)
-					}
-				}
-			}
+			allDataSources = append(allDataSources, dataSources...)
 		}
 
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "  Found %d databases so far...\n", len(allDatabases))
@@ -164,10 +115,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	wc.SetDatabases(allDatabases)
 	wc.SetDataSources(allDataSources)
 	if err := wc.Save(); err != nil {
-		return handleError(cmd, &clierrors.NotionCLIError{
-			Code:    clierrors.CodeInternalError,
-			Message: fmt.Sprintf("Failed to save workspace cache: %s", err),
-		})
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to save workspace cache", err))
 	}
 
 	elapsed := time.Since(start)
@@ -181,6 +129,150 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		"elapsed_ms":   elapsed.Milliseconds(),
 	}, "sync", start)
 	return nil
+}
+
+func cacheEntriesFromSearchResult(result map[string]any) (cache.DatabaseEntry, []cache.DataSourceEntry, bool) {
+	switch result["object"] {
+	case "data_source":
+		return cacheEntriesFromDataSourceSearchResult(result)
+	case "database":
+		return cacheEntriesFromDatabaseSearchResult(result)
+	default:
+		return cache.DatabaseEntry{}, nil, false
+	}
+}
+
+func cacheEntriesFromDataSourceSearchResult(ds map[string]any) (cache.DatabaseEntry, []cache.DataSourceEntry, bool) {
+	dataSourceID := stringField(ds, "id")
+	if dataSourceID == "" {
+		return cache.DatabaseEntry{}, nil, false
+	}
+
+	databaseID := parentDatabaseID(ds)
+	if databaseID == "" {
+		databaseID = dataSourceID
+	}
+
+	title := titleFromSearchResult(ds)
+	lastEdited := parseNotionEditedTime(ds)
+	url := stringField(ds, "url")
+	dbEntry := cache.DatabaseEntry{
+		ID:           databaseID,
+		Title:        title,
+		DataSourceID: dataSourceID,
+		URL:          url,
+		Aliases:      generateAliases(title),
+		LastEdited:   lastEdited,
+	}
+	dsEntry := cache.DataSourceEntry{
+		ID:         dataSourceID,
+		DatabaseID: databaseID,
+		Title:      title,
+		URL:        url,
+		LastEdited: lastEdited,
+	}
+	return dbEntry, []cache.DataSourceEntry{dsEntry}, true
+}
+
+func cacheEntriesFromDatabaseSearchResult(db map[string]any) (cache.DatabaseEntry, []cache.DataSourceEntry, bool) {
+	databaseID := stringField(db, "id")
+	if databaseID == "" {
+		return cache.DatabaseEntry{}, nil, false
+	}
+
+	title := titleFromSearchResult(db)
+	lastEdited := parseNotionEditedTime(db)
+	url := stringField(db, "url")
+	dbEntry := cache.DatabaseEntry{
+		ID:         databaseID,
+		Title:      title,
+		URL:        url,
+		Aliases:    generateAliases(title),
+		LastEdited: lastEdited,
+	}
+
+	var dataSources []cache.DataSourceEntry
+	if dsArr, ok := db["data_sources"].([]any); ok {
+		for _, rawDS := range dsArr {
+			dsMap, ok := rawDS.(map[string]any)
+			if !ok {
+				continue
+			}
+			dataSourceID := stringField(dsMap, "id")
+			if dataSourceID == "" {
+				continue
+			}
+			if dbEntry.DataSourceID == "" {
+				dbEntry.DataSourceID = dataSourceID
+			}
+			dsTitle := titleFromSearchResult(dsMap)
+			if dsTitle == "" {
+				dsTitle = title
+			}
+			dsURL := stringField(dsMap, "url")
+			if dsURL == "" {
+				dsURL = url
+			}
+			dsLastEdited := parseNotionEditedTime(dsMap)
+			if dsLastEdited.IsZero() {
+				dsLastEdited = lastEdited
+			}
+			dataSources = append(dataSources, cache.DataSourceEntry{
+				ID:         dataSourceID,
+				DatabaseID: databaseID,
+				Title:      dsTitle,
+				URL:        dsURL,
+				LastEdited: dsLastEdited,
+			})
+		}
+	}
+	return dbEntry, dataSources, true
+}
+
+func titleFromSearchResult(item map[string]any) string {
+	titleArr, ok := item["title"].([]any)
+	if !ok {
+		return ""
+	}
+	var parts []string
+	for _, t := range titleArr {
+		tm, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		if plainText, ok := tm["plain_text"].(string); ok {
+			parts = append(parts, plainText)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func parentDatabaseID(item map[string]any) string {
+	parent, ok := item["parent"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringField(parent, "database_id")
+}
+
+func parseNotionEditedTime(item map[string]any) time.Time {
+	edited := stringField(item, "last_edited_time")
+	if edited == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, edited)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func stringField(item map[string]any, key string) string {
+	value, ok := item[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
 }
 
 // generateAliases creates search aliases from a database title.

--- a/internal/cli/commands/sync_test.go
+++ b/internal/cli/commands/sync_test.go
@@ -146,15 +146,21 @@ func TestSync_Force(t *testing.T) {
 		}
 	})
 
+	var capturedBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"results": []any{
 				map[string]any{
-					"object": "database",
+					"object": "data_source",
 					"id":     "db-1",
-					"title": []any{map[string]any{"plain_text": "My DB"}},
+					"parent": map[string]any{
+						"type":        "database_id",
+						"database_id": "parent-db-1",
+					},
+					"title":            []any{map[string]any{"plain_text": "My DB"}},
 					"last_edited_time": time.Now().Format(time.RFC3339),
 				},
 			},
@@ -175,5 +181,28 @@ func TestSync_Force(t *testing.T) {
 	_, _, err := runSyncRoot(t, "sync", "--force")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filter, ok := capturedBody["filter"].(map[string]any)
+	if !ok {
+		t.Fatal("filter field missing from sync request")
+	}
+	if filter["value"] != "data_source" {
+		t.Errorf("filter.value = %v, want data_source", filter["value"])
+	}
+
+	raw, err := os.ReadFile(tmpDir + "/.notion-cli/databases.json")
+	if err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+	var saved map[string]any
+	if err := json.Unmarshal(raw, &saved); err != nil {
+		t.Fatalf("cache file invalid JSON: %v", err)
+	}
+	if got := len(saved["databases"].([]any)); got != 1 {
+		t.Fatalf("cached databases = %d, want 1", got)
+	}
+	if got := len(saved["data_sources"].([]any)); got != 1 {
+		t.Fatalf("cached data sources = %d, want 1", got)
 	}
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -80,6 +80,14 @@ func (e *NotionCLIError) Error() string {
 	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
 }
 
+// DisplayMessage returns the message shown in CLI error output.
+func (e *NotionCLIError) DisplayMessage() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
 // Unwrap returns the underlying error, supporting errors.Is/As chains.
 func (e *NotionCLIError) Unwrap() error {
 	return e.Err
@@ -96,6 +104,15 @@ func (e *NotionCLIError) ExitCode() int {
 // ---------------------------------------------------------------------------
 // Factory functions
 // ---------------------------------------------------------------------------
+
+// Wrap returns a NotionCLIError with an underlying cause.
+func Wrap(code, message string, err error) *NotionCLIError {
+	return &NotionCLIError{
+		Code:    code,
+		Message: message,
+		Err:     err,
+	}
+}
 
 // TokenMissing returns an error indicating no API token is configured.
 func TokenMissing() *NotionCLIError {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -28,6 +28,14 @@ func TestNotionCLIError_Error(t *testing.T) {
 	})
 }
 
+func TestNotionCLIError_DisplayMessage(t *testing.T) {
+	inner := fmt.Errorf("connection refused")
+	e := &NotionCLIError{Code: CodeNetworkError, Message: "network fail", Err: inner}
+	if got, want := e.DisplayMessage(), "network fail: connection refused"; got != want {
+		t.Errorf("DisplayMessage() = %q, want %q", got, want)
+	}
+}
+
 func TestNotionCLIError_Unwrap(t *testing.T) {
 	inner := fmt.Errorf("root cause")
 	e := &NotionCLIError{Code: CodeInternalError, Message: "oops", Err: inner}
@@ -39,6 +47,20 @@ func TestNotionCLIError_Unwrap(t *testing.T) {
 	e2 := &NotionCLIError{Code: CodeInternalError, Message: "no wrap"}
 	if e2.Unwrap() != nil {
 		t.Error("Unwrap should return nil when no wrapped error")
+	}
+}
+
+func TestWrap(t *testing.T) {
+	inner := fmt.Errorf("disk full")
+	e := Wrap(CodeInternalError, "Failed to save config", inner)
+	if e.Code != CodeInternalError {
+		t.Errorf("Code = %q, want %q", e.Code, CodeInternalError)
+	}
+	if e.Message != "Failed to save config" {
+		t.Errorf("Message = %q", e.Message)
+	}
+	if !errors.Is(e, inner) {
+		t.Error("Wrap should preserve the underlying error")
 	}
 }
 


### PR DESCRIPTION
## Summary

Notion search now returns database-like objects through the `data_source` filter. This updates the CLI paths that still asked search for `database` objects, while keeping `--property database` as a compatibility alias for users.

This also pulls two small shared helpers into place:

- `clierrors.Wrap` for repeated wrapped CLI errors
- `outputFormatExplicit` for commands that need to know whether the caller requested structured output

## Changes

- Use `data_source` for search and sync filters.
- Teach `sync` to cache results returned as `data_source` objects, including the parent database ID when Notion provides it.
- Keep `database`/`db` as accepted search aliases.
- Add tests for search filter behavior and sync cache output.
- Replace repeated local error-wrapping boilerplate in the touched paths.

## Testing

- `make test`
- `make build`
- `make lint`
