### PR TITLE
fix: add Notion-Version and Accept headers to OAuth token requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OAuth token endpoint requests now include `Notion-Version` and `Accept: application/json` headers, matching the official Notion JS SDK (`makenotion/notion-sdk-js`) and developer-docs spec. Applied to `exchangeCode`, `TokenRefresh`, `TokenIntrospect`, and `TokenRevoke` in `internal/oauth/oauth.go`.
+
 ## [6.3.1] - 2026-05-11
 
 ### Breaking

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -39,6 +39,12 @@ const (
 
 	// maxResponseBody limits the token exchange response to 1 MB.
 	maxResponseBody = 1 << 20
+
+	// notionVersion is the Notion API version sent on OAuth requests.
+	// Matches the default in internal/notion/client.go and the official
+	// makenotion/notion-sdk-js, which sends Notion-Version on every request
+	// including OAuth endpoints. Keep in sync with defaultNotionVersion.
+	notionVersion = "2026-03-11"
 )
 
 // redirectURIFor returns the canonical redirect URI for the given port. It
@@ -330,6 +336,8 @@ func exchangeCode(ctx context.Context, clientID, clientSecret, redirectURI, code
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
 	req.SetBasicAuth(clientID, clientSecret)
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
@@ -392,6 +400,8 @@ func TokenRefresh(ctx context.Context, clientID, clientSecret, refreshToken stri
 		return nil, clierrors.OAuthFailed(err.Error())
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
 	req.SetBasicAuth(clientID, clientSecret)
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
@@ -440,6 +450,8 @@ func TokenIntrospect(ctx context.Context, clientID, clientSecret, token string) 
 		return nil, clierrors.OAuthFailed(err.Error())
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
 	req.SetBasicAuth(clientID, clientSecret)
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
@@ -485,6 +497,8 @@ func TokenRevoke(ctx context.Context, clientID, clientSecret, token string) erro
 		return clierrors.OAuthFailed(err.Error())
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", notionVersion)
 	req.SetBasicAuth(clientID, clientSecret)
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -175,6 +175,16 @@ func TestExchangeCode_Success(t *testing.T) {
 			t.Errorf("Content-Type = %q, want application/json", ct)
 		}
 
+		// Verify Accept header (defensive — some OAuth servers content-negotiate).
+		if a := r.Header.Get("Accept"); a != "application/json" {
+			t.Errorf("Accept = %q, want application/json", a)
+		}
+
+		// Verify Notion-Version header (matches official notion-sdk-js behavior).
+		if v := r.Header.Get("Notion-Version"); v != notionVersion {
+			t.Errorf("Notion-Version = %q, want %q", v, notionVersion)
+		}
+
 		resp := TokenResponse{
 			AccessToken:   "ntn_test_token_abc123",
 			TokenType:     "bearer",
@@ -300,6 +310,72 @@ func TestLogin_ContextCancelled(t *testing.T) {
 	}
 	if cliErr.Code != clierrors.CodeOAuthTimeout {
 		t.Errorf("error code = %q, want %q", cliErr.Code, clierrors.CodeOAuthTimeout)
+	}
+}
+
+// assertOAuthHeaders fails the test if the request is missing any of the
+// three headers we send on every OAuth endpoint call: Content-Type,
+// Accept, and Notion-Version.
+func assertOAuthHeaders(t *testing.T, r *http.Request) {
+	t.Helper()
+	if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if a := r.Header.Get("Accept"); a != "application/json" {
+		t.Errorf("Accept = %q, want application/json", a)
+	}
+	if v := r.Header.Get("Notion-Version"); v != notionVersion {
+		t.Errorf("Notion-Version = %q, want %q", v, notionVersion)
+	}
+}
+
+func TestTokenRefresh_SendsHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOAuthHeaders(t, r)
+		_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "new-token"})
+	}))
+	defer server.Close()
+
+	origURL := tokenURL
+	tokenURL = server.URL
+	defer func() { tokenURL = origURL }()
+
+	_, err := TokenRefresh(context.Background(), "id", "secret", "refresh-tok")
+	if err != nil {
+		t.Fatalf("TokenRefresh() error: %v", err)
+	}
+}
+
+func TestTokenIntrospect_SendsHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOAuthHeaders(t, r)
+		_ = json.NewEncoder(w).Encode(IntrospectResponse{Active: true})
+	}))
+	defer server.Close()
+
+	origURL := introspectURL
+	introspectURL = server.URL
+	defer func() { introspectURL = origURL }()
+
+	_, err := TokenIntrospect(context.Background(), "id", "secret", "tok")
+	if err != nil {
+		t.Fatalf("TokenIntrospect() error: %v", err)
+	}
+}
+
+func TestTokenRevoke_SendsHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertOAuthHeaders(t, r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	origURL := revokeURL
+	revokeURL = server.URL
+	defer func() { revokeURL = origURL }()
+
+	if err := TokenRevoke(context.Background(), "id", "secret", "tok"); err != nil {
+		t.Fatalf("TokenRevoke() error: %v", err)
 	}
 }
 


### PR DESCRIPTION
All four OAuth endpoint calls (exchangeCode, TokenRefresh, TokenIntrospect, TokenRevoke) now send Notion-Version and Accept: application/json headers, matching the official Notion JS SDK and developer-docs spec.