### PR TITLE
chore: release v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-06-23
+
 ### Added
 - **Workspace-scoped OAuth credentials.** `auth login` now stores OAuth credentials per Notion workspace using a slug derived from the workspace name, with `--slug` for overrides. Added `auth list`, `auth default [workspace]`, `auth logout [workspace]`, global `--auth-workspace`, and `NOTION_WORKSPACE` selection.
   - Keychain-backed secret storage for named workspace credentials. Non-secret workspace metadata is stored in `~/.config/notion-cli/credentials.json`; OAuth access and refresh tokens are stored in the OS keychain.

--- a/npm/notion-cli-darwin-arm64/package.json
+++ b/npm/notion-cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli-darwin-arm64",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "notion-cli binary for macOS ARM64 (Apple Silicon)",
   "os": [
     "darwin"

--- a/npm/notion-cli-darwin-x64/package.json
+++ b/npm/notion-cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli-darwin-x64",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "notion-cli binary for macOS x64 (Intel)",
   "os": [
     "darwin"

--- a/npm/notion-cli-linux-arm64/package.json
+++ b/npm/notion-cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli-linux-arm64",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "notion-cli binary for Linux ARM64",
   "os": [
     "linux"

--- a/npm/notion-cli-linux-x64/package.json
+++ b/npm/notion-cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli-linux-x64",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "notion-cli binary for Linux x64",
   "os": [
     "linux"

--- a/npm/notion-cli-win32-x64/package.json
+++ b/npm/notion-cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli-win32-x64",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "notion-cli binary for Windows x64",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coastal-programs/notion-cli",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "description": "Unofficial Notion CLI optimized for automation and AI agents. Single-binary Go implementation with intelligent caching, retry logic, structured error handling.",
   "author": "Jake Schepis <jake@coastalprograms.com>",
   "bin": {
@@ -24,11 +24,11 @@
     "release": "make release"
   },
   "optionalDependencies": {
-    "@coastal-programs/notion-cli-darwin-arm64": "6.3.3",
-    "@coastal-programs/notion-cli-darwin-x64": "6.3.3",
-    "@coastal-programs/notion-cli-linux-x64": "6.3.3",
-    "@coastal-programs/notion-cli-linux-arm64": "6.3.3",
-    "@coastal-programs/notion-cli-win32-x64": "6.3.3"
+    "@coastal-programs/notion-cli-darwin-arm64": "6.4.0",
+    "@coastal-programs/notion-cli-darwin-x64": "6.4.0",
+    "@coastal-programs/notion-cli-linux-x64": "6.4.0",
+    "@coastal-programs/notion-cli-linux-arm64": "6.4.0",
+    "@coastal-programs/notion-cli-win32-x64": "6.4.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Version bump 6.3.3 → 6.4.0 (main + 5 platform packages + optionalDependencies pins) and CHANGELOG stamp.

**Minor bump** — new features, no breaking changes:
- Workspace-scoped OAuth credentials (keychain-backed, multi-workspace, interactive selector)
- `db create`/`db update` column-schema editing (#97)
- CI: secret-free PR cross-compile; Dependabot auto-merge + grouping

After merge, tag `v6.4.0` to trigger `publish.yml` (which pauses for manual approval on the `npm-publish` environment before publishing).