### PR TITLE
feat: add ntn-compatible API parity command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `api <path>` command with official `ntn api`-style authenticated requests, including inline body/query/header syntax (`=`, `:=`, `==`, `Header:Value`), stdin/`--data` JSON bodies, `--file` multipart uploads, method overrides, raw-default output, and embedded endpoint `ls`/`--spec`/`--docs` introspection.
+- Official CLI compatibility aliases: root `login`/`logout`, `datasources` for `data-source`, `datasources resolve`, `pages get/create/update/trash`, and `files create/get/list` with stdin uploads, external URL imports, `--plain`, filename, and content-type overrides.
+- `NOTION_API_TOKEN` is accepted as an auth token alias after `NOTION_TOKEN`, and `NOTION_API_VERSION` / `--notion-version` can override the `Notion-Version` request header.
+- Embedded Notion API catalog refresh helper at `scripts/refresh_notion_api_catalog.sh`.
+
 ## [6.4.1] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ A powerful command-line interface for the Notion API, optimized for AI coding as
 - **Cross-platform**: macOS (arm64, amd64), Linux (amd64, arm64), Windows (amd64)
 - **Near-zero supply chain risk**: 2 Go dependencies (cobra, pflag) vs 573 npm packages in v5.x
 
-## What's New in v6.0.0
+## What's New in v6
 
-**Complete rewrite from TypeScript/oclif to Go/Cobra.**
+**v6.0.0: Complete rewrite from TypeScript/oclif to Go/Cobra.**
 
 All 26 commands have been ported with identical syntax -- existing scripts work unchanged. The JSON envelope format (`{success, data, metadata}`) and environment variables (`NOTION_TOKEN`) are the same.
 
@@ -63,7 +63,7 @@ All 26 commands have been ported with identical syntax -- existing scripts work 
 
 **v6.1.0: OAuth Authentication** -- `notion-cli auth login` opens your browser, you authorize, done. No more copying tokens manually.
 
-**Unreleased (next):**
+**Current v6 capabilities: official ntn-style API parity and data-source updates.**
 - `api <path>` command compatible with official `ntn api` request syntax, including inline `=`, `:=`, `==`, and `Header:Value` arguments, stdin/`--data`, `--file`, `api ls`, `--spec`, and `--docs`.
 - Official-style aliases: root `login`/`logout`, `datasources`, `pages`, and `files create/get/list`.
 - `NOTION_API_TOKEN`, `NOTION_API_VERSION`, and `--notion-version` compatibility.
@@ -74,11 +74,11 @@ All 26 commands have been ported with identical syntax -- existing scripts work 
 - Resolver handles `?dataSource=<id>` query params in Notion URLs.
 
 **Technical details:**
-- 36 Go source files, ~9,800 lines of code
-- 196 tests across 9 test suites, all passing
+- Go/Cobra command suite with focused command, client, and parser tests
+- Single stripped Go binary with no runtime dependency on Node.js
 - ~8MB binary (stripped, darwin/arm64)
 
-**Deferred to Phase 2:** Disk cache, request deduplication, circuit breaker, simple properties (`-S` flag), recursive page retrieval, markdown output from page content, interactive init wizard, update notifications.
+**Still planned:** Disk cache, request deduplication, circuit breaker, simple properties (`-S` flag), recursive page retrieval, interactive init wizard, and update notifications.
 
 See [CHANGELOG.md](./CHANGELOG.md) for full details.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A powerful command-line interface for the Notion API, optimized for AI coding as
 **Key Features:**
 - **Single binary**: ~8MB, zero runtime dependencies, instant startup
 - **OAuth login**: `notion-cli auth login` -- authenticate in your browser, no token management
+- **Official API parity**: `notion-cli api` supports `ntn api`-style raw requests, inline typed JSON, query params, headers, endpoint docs/spec lookup, and multipart file sends
 - **AI-first design**: JSON envelope output, structured errors, exit codes
 - **Non-interactive**: Perfect for scripts and automation
 - **Flexible output**: JSON, CSV, table, or raw API responses
@@ -63,6 +64,9 @@ All 26 commands have been ported with identical syntax -- existing scripts work 
 **v6.1.0: OAuth Authentication** -- `notion-cli auth login` opens your browser, you authorize, done. No more copying tokens manually.
 
 **Unreleased (next):**
+- `api <path>` command compatible with official `ntn api` request syntax, including inline `=`, `:=`, `==`, and `Header:Value` arguments, stdin/`--data`, `--file`, `api ls`, `--spec`, and `--docs`.
+- Official-style aliases: root `login`/`logout`, `datasources`, `pages`, and `files create/get/list`.
+- `NOTION_API_TOKEN`, `NOTION_API_VERSION`, and `--notion-version` compatibility.
 - `data-source templates` and `data-source properties update` subcommands.
 - `db query` emits a deprecation notice (suppress with `--quiet`); migrate to `data-source query <id>` for direct access.
 - `ds` alias now routes to `data-source` (was `db`) — update any scripts using `notion-cli ds`.
@@ -120,6 +124,10 @@ notion-cli whoami
 # Set your Notion API token
 export NOTION_TOKEN="secret_your_token_here"
 
+# Official Notion CLI-compatible aliases also work
+export NOTION_API_TOKEN="$NOTION_TOKEN"
+export NOTION_API_VERSION="2026-03-11"
+
 # Or save it to the config file
 notion-cli config set-token <YOUR_TOKEN>
 ```
@@ -149,17 +157,55 @@ notion-cli page create --database-id <DATABASE_ID> \
 
 # Search the workspace
 notion-cli search "project" --output json
+
+# Make an official ntn-style raw API request
+notion-cli api v1/search query=project page_size:=10
 ```
 
 All commands support `--output json` for machine-readable responses.
 
 ## Commands
 
+### Raw API Requests
+
+```bash
+# GET by default when no body is supplied
+notion-cli api v1/users/me
+
+# POST by default when inline body fields are supplied
+notion-cli api v1/search query=roadmap page_size:=10
+
+# PATCH with typed JSON and a custom header
+notion-cli api "v1/pages/$PAGE_ID" -X PATCH \
+  archived:=true \
+  X-Trace-Id:cli-test-123
+
+# Query parameters and endpoint introspection
+notion-cli api v1/file_uploads page_size==25
+notion-cli api ls --json
+notion-cli api v1/comments --spec -X POST
+notion-cli api v1/comments --docs -X POST
+
+# Multipart file send for low-level upload control
+notion-cli api "v1/file_uploads/$FILE_UPLOAD_ID/send" \
+  --file ./chunk.bin \
+  part_number:=1
+```
+
+Inline syntax matches official `ntn api`: `path=value` for string body fields,
+`path:=json` for typed JSON body fields, `name==value` for query parameters,
+and `Header:Value` for request headers. Body paths support bracket and dot
+notation, indexed arrays, and `[]` appends.
+
 ### Authentication
 
 ```bash
 # Log in via OAuth (opens browser)
 notion-cli auth login
+
+# Official-style aliases
+notion-cli login
+notion-cli logout
 
 # Check current auth status
 notion-cli auth status
@@ -211,6 +257,10 @@ notion-cli db update <DATABASE_ID> --title "New Title"
 
 # Extract schema (AI-friendly)
 notion-cli db schema <DATABASE_ID> --output json
+
+# Official-style data source aliases
+notion-cli datasources query <DATA_SOURCE_ID> --limit 50 --json
+notion-cli datasources resolve <DATABASE_ID> --json
 ```
 
 ### Page Commands
@@ -230,6 +280,12 @@ notion-cli page update <PAGE_ID> \
 
 # Get page property item
 notion-cli page property-item <PAGE_ID> --property-id <PROPERTY_ID>
+
+# Official-style markdown page aliases
+notion-cli pages get <PAGE_ID>
+notion-cli pages create --parent page:<PAGE_ID> --content "# Meeting notes"
+notion-cli pages update <PAGE_ID> --content "# Updated notes"
+notion-cli pages trash <PAGE_ID> --yes
 ```
 
 ### Block Commands
@@ -263,6 +319,19 @@ notion-cli user retrieve <USER_ID>
 
 # Get bot user info
 notion-cli user bot
+```
+
+### File Upload Commands
+
+```bash
+# Existing path-based upload
+notion-cli files upload ./photo.png --json
+
+# Official-style stdin upload and external URL import
+notion-cli files create --filename photo.png --content-type image/png < ./photo.png
+notion-cli files create --external-url https://example.com/photo.png --filename photo.png --plain
+notion-cli files get <FILE_UPLOAD_ID> --plain
+notion-cli files list --json
 ```
 
 ### Search

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Individual command documentation:
 - **[doctor](doctor.md)** - Health checks and diagnostics
 - **[config](config.md)** - Configuration management (set-token, get, path, list)
 - **[cache](cache.md)** - Cache info and statistics
+- **[api](api.md)** - Official ntn-style raw API requests and endpoint introspection
 - **[help](help.md)** - Built-in help system
 
 ## User Guides

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 This directory contains comprehensive documentation for the Notion CLI.
 
-> **Note:** As of v6.0.0, notion-cli has been completely rewritten from TypeScript to Go.
+> **Note:** Since v6.0.0, notion-cli has been a Go/Cobra rewrite of the TypeScript CLI.
 > It is distributed as a single ~8MB binary via npm (platform-specific packages) or built from source with `make build`.
-> All 26 commands from v5.x are fully ported with identical syntax and output formats.
+> Current source builds also include official `ntn`-style API request compatibility, workspace OAuth, and data-source-first commands.
 
 ## Command Reference
 
@@ -72,14 +72,14 @@ make tidy      # go mod tidy
 
 ## Phase 2 Features (Planned)
 
-The following v5.x features are planned for a future release:
+The following features are still planned for a future release:
 
-- Interactive setup wizard (`init` command)
+- Disk cache
+- Request deduplication
+- Circuit breaker
 - Simple properties (`-S` flag) for page create/update
 - Recursive page retrieval (`-R` flag)
-- Markdown output from page content
-- Disk cache and request deduplication
-- Circuit breaker
+- Interactive setup wizard (`init` command)
 - Update notifications
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,57 @@
+# API Command
+
+`notion-cli api` makes authenticated Notion API requests from the terminal with
+syntax compatible with the official `ntn api` command.
+
+## Examples
+
+```bash
+# GET request
+notion-cli api v1/users/me
+
+# POST request with typed inline JSON
+notion-cli api v1/search query=roadmap page_size:=10
+
+# PATCH request
+notion-cli api "v1/pages/$PAGE_ID" -X PATCH archived:=true
+
+# Query parameters and headers
+notion-cli api v1/file_uploads page_size==25 Accept:application/json
+
+# JSON body from stdin or --data
+jq -n '{query:"roadmap",page_size:10}' | notion-cli api v1/search
+notion-cli api v1/search --data '{"query":"roadmap","page_size":10}'
+
+# Multipart file send
+notion-cli api "v1/file_uploads/$FILE_UPLOAD_ID/send" --file ./chunk.bin part_number:=1
+```
+
+## Inline Syntax
+
+- `path=value`: body field with a string value.
+- `path:=json`: body field parsed as JSON.
+- `name==value`: query parameter.
+- `Header:Value`: request header.
+
+Body paths support bracket notation, dot notation, explicit array indexes, and
+`[]` appends.
+
+## Introspection
+
+```bash
+notion-cli api ls
+notion-cli api ls --json
+notion-cli api v1/comments --spec -X POST
+notion-cli api v1/comments --docs -X POST
+```
+
+The introspection catalog is embedded for deterministic offline output. Refresh
+the source material with `scripts/refresh_notion_api_catalog.sh` before updating
+the catalog.
+
+## Compatibility Notes
+
+`NOTION_TOKEN` remains the primary automation token. `NOTION_API_TOKEN` is also
+accepted for official CLI compatibility when `NOTION_TOKEN` is unset.
+
+`NOTION_API_VERSION` and `--notion-version` override the `Notion-Version` header.

--- a/docs/init.md
+++ b/docs/init.md
@@ -1,7 +1,7 @@
 `notion-cli init`
 =================
 
-> **Note:** The `init` command is planned for a future release (Phase 2). It is not available in the current Go rewrite (v6.0.0).
+> **Note:** The standalone `init` wizard is planned for a future release. Current Go builds use OAuth login and first-run setup instead.
 
 Interactive first-time setup wizard for Notion CLI
 
@@ -9,17 +9,32 @@ Interactive first-time setup wizard for Notion CLI
 
 This command was available in v5.x (TypeScript) and will be re-implemented in a future Go release.
 
-## Alternative Setup (v6.0.0)
+Current Go builds use OAuth login and first-run setup instead of a standalone
+`init` command. In an interactive shell, commands that need the Notion API can
+start OAuth setup automatically when no credentials exist. Non-interactive
+shells print setup instructions instead of opening a browser.
 
-In the current version, set up your token using one of these methods:
+## Current Setup
 
-**Option 1: Environment variable (recommended)**
+**Option 1: OAuth login (recommended for interactive use)**
+
+```bash
+notion-cli auth login
+
+# Official-style alias
+notion-cli login
+```
+
+**Option 2: Environment variable (recommended for CI and automation)**
 
 ```bash
 export NOTION_TOKEN="secret_your_token_here"
+
+# Official CLI compatibility alias when NOTION_TOKEN is unset
+export NOTION_API_TOKEN="secret_your_token_here"
 ```
 
-**Option 2: Config file**
+**Option 3: Legacy config file**
 
 ```bash
 # Set token via config command
@@ -29,7 +44,7 @@ notion-cli config set-token
 echo "$NOTION_TOKEN" | notion-cli config set-token
 ```
 
-**Option 3: Verify setup**
+**Verify setup**
 
 ```bash
 # Check connectivity
@@ -41,4 +56,3 @@ notion-cli doctor
 # Sync workspace databases
 notion-cli sync
 ```
-

--- a/docs/user-guides/ai-agent-guide.md
+++ b/docs/user-guides/ai-agent-guide.md
@@ -12,7 +12,7 @@ This guide provides comprehensive instructions for AI agents to effectively use 
 2. [First-Time Setup](#first-time-setup)
 3. [Health Checks & Diagnostics](#health-checks--diagnostics)
 4. [Core Workflow](#core-workflow)
-5. [Simple Properties Mode](#simple-properties-mode)
+5. [Planned Simple Properties Mode](#planned-simple-properties-mode)
 6. [Database Operations](#database-operations)
 7. [Troubleshooting](#troubleshooting)
 8. [Best Practices](#best-practices)
@@ -43,10 +43,16 @@ notion-cli --version
 
 ## First-Time Setup
 
-### Token Setup
+### Authentication Setup
 
 ```bash
-# Mac/Linux
+# Recommended for interactive use
+notion-cli auth login
+
+# Official-style alias
+notion-cli login
+
+# Mac/Linux automation
 export NOTION_TOKEN="secret_your_token_here"
 
 # Windows (Command Prompt)
@@ -55,7 +61,7 @@ set NOTION_TOKEN=secret_your_token_here
 # Windows (PowerShell)
 $env:NOTION_TOKEN="secret_your_token_here"
 
-# Or use the config command
+# Or use the legacy config command
 notion-cli config set-token
 ```
 
@@ -121,8 +127,8 @@ notion-cli whoami
 # Run health check
 notion-cli doctor
 
-# If any checks fail, init command will guide you
-notion-cli init
+# If auth is missing in an interactive shell, start OAuth setup
+notion-cli auth login
 ```
 
 **2. Sync Workspace (One-Time Setup)**
@@ -171,9 +177,9 @@ notion-cli db query <ID> --search "urgent" --json
 
 ---
 
-## Simple Properties Mode (Phase 2)
+## Planned Simple Properties Mode
 
-> **Note:** Simple Properties (`-S` flag) is a Phase 2 feature not yet available in v6.0.0. For now, use the standard Notion API property format when creating/updating pages. This feature will be added in a future release.
+> **Note:** Simple Properties (`-S` flag) is still planned. For now, use the standard Notion API property format when creating/updating pages.
 
 ---
 
@@ -235,7 +241,7 @@ notion-cli list --json
 
 ```bash
 # Check cache status
-notion-cli cache:info --json
+notion-cli cache info --json
 
 # Sync workspace
 notion-cli sync
@@ -261,8 +267,8 @@ This will identify the specific issue (token, connectivity, permissions, etc.)
 
 **Issue: Token Not Configured**
 ```bash
-# Solution: Run init wizard
-notion-cli init
+# Solution: Start OAuth login in an interactive shell
+notion-cli auth login
 
 # Or set manually
 export NOTION_TOKEN="secret_your_token_here"
@@ -273,8 +279,8 @@ export NOTION_TOKEN="secret_your_token_here"
 # Check token validity
 notion-cli whoami
 
-# Re-run setup
-notion-cli init
+# Re-run OAuth setup
+notion-cli auth login
 ```
 
 **Issue: Database Not Found**
@@ -291,8 +297,8 @@ notion-cli sync
 # Get schema to see valid properties
 notion-cli db schema <ID> --with-examples --json
 
-# Use simple properties for easier syntax
-notion-cli page create -d <ID> -S --properties '{...}'
+# Use the standard Notion API property shape
+notion-cli page create -d <ID> --properties '{...}'
 ```
 
 **Issue: Permission Denied**
@@ -315,7 +321,7 @@ Error: NOTION_TOKEN not found
 Set your token:
   set NOTION_TOKEN=secret_your_token_here
 
-Or run: notion-cli init
+Or run: notion-cli auth login
 ```
 
 **Windows (PowerShell):**
@@ -325,7 +331,7 @@ Error: NOTION_TOKEN not found
 Set your token:
   $env:NOTION_TOKEN="secret_your_token_here"
 
-Or run: notion-cli init
+Or run: notion-cli auth login
 ```
 
 **Unix/Mac:**
@@ -335,7 +341,7 @@ Error: NOTION_TOKEN not found
 Set your token:
   export NOTION_TOKEN="secret_your_token_here"
 
-Or run: notion-cli init
+Or run: notion-cli auth login
 ```
 
 ---
@@ -371,7 +377,7 @@ notion-cli db query <ID> --json | jq '.data.results'
 **5. Check Cache Freshness**
 ```bash
 # Before bulk operations
-notion-cli cache:info --json
+notion-cli cache info --json
 ```
 
 **6. Sync Workspace Periodically**
@@ -474,7 +480,7 @@ notion-cli doctor
 
 ```bash
 # Setup & Health
-notion-cli init           # First-time setup wizard
+notion-cli auth login     # First-time OAuth setup
 notion-cli doctor         # Comprehensive health check
 notion-cli whoami         # Quick connection test
 
@@ -493,11 +499,11 @@ notion-cli page update <ID> --properties '{...}'
 notion-cli db query <ID> --filter '{...}' --json
 
 # Cache Management
-notion-cli cache:info --json
+notion-cli cache info --json
 ```
 
 **Recommended Workflow:**
-1. `notion-cli init` - First-time setup
+1. `notion-cli auth login` - First-time OAuth setup
 2. `notion-cli doctor` - Verify health
 3. `notion-cli sync` - Cache workspace
 4. `notion-cli db schema <ID> --output json` - Discover structure

--- a/internal/cli/commands/api.go
+++ b/internal/cli/commands/api.go
@@ -1,0 +1,332 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	clierrors "github.com/Coastal-Programs/notion-cli/v6/internal/errors"
+	"github.com/Coastal-Programs/notion-cli/v6/internal/notion"
+	"github.com/Coastal-Programs/notion-cli/v6/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+// RegisterAPICommands registers the ntn-compatible generic API command.
+func RegisterAPICommands(root *cobra.Command) {
+	apiCmd := &cobra.Command{
+		Use:   "api <path> [field=value ...]",
+		Short: "Make authenticated Notion API requests",
+		Long: "Make authenticated Notion API requests with ntn-compatible inline body, query, and header syntax.\n\n" +
+			"Forms:\n" +
+			"  path=value       body field with string value\n" +
+			"  path:=json       body field parsed as JSON\n" +
+			"  name==value      query parameter\n" +
+			"  Header:Value     request header",
+		Args: cobra.MinimumNArgs(1),
+		RunE: runAPI,
+	}
+	apiCmd.Flags().StringP("method", "X", "", "HTTP method")
+	apiCmd.Flags().String("data", "", "JSON request body")
+	apiCmd.Flags().String("file", "", "Send a multipart form-data request with this file as field \"file\"")
+	apiCmd.Flags().Bool("spec", false, "Print the embedded reduced OpenAPI fragment for this endpoint")
+	apiCmd.Flags().Bool("docs", false, "Print the embedded markdown docs for this endpoint")
+	apiCmd.Flags().Bool("unsafe-verbose", false, "Do not redact Authorization in verbose logs")
+	_ = apiCmd.Flags().MarkHidden("unsafe-verbose")
+	addOutputFlags(apiCmd)
+
+	lsCmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List embedded Notion API endpoints",
+		Args:  cobra.NoArgs,
+		RunE:  runAPILS,
+	}
+	addOutputFlags(lsCmd)
+	apiCmd.AddCommand(lsCmd)
+
+	root.AddCommand(apiCmd)
+}
+
+func runAPILS(cmd *cobra.Command, _ []string) error {
+	start := time.Now()
+	p := output.NewPrinter(outputFormat(cmd))
+	p.Writer = cmd.OutOrStdout()
+	p.PrintSuccess(apiCatalogRows(), "api ls", start)
+	return nil
+}
+
+func runAPI(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+	path := args[0]
+	inlineArgs := args[1:]
+
+	method, _ := cmd.Flags().GetString("method")
+	method = strings.ToUpper(strings.TrimSpace(method))
+	methodExplicit := method != ""
+
+	if spec, _ := cmd.Flags().GetBool("spec"); spec {
+		return printAPISpec(cmd, path, method, methodExplicit)
+	}
+	if docs, _ := cmd.Flags().GetBool("docs"); docs {
+		return printAPIDocs(cmd, path, method, methodExplicit)
+	}
+
+	parsed, err := parseAPIInlineArgs(inlineArgs)
+	if err != nil {
+		return handleError(cmd, &clierrors.NotionCLIError{Code: clierrors.CodeInvalidRequest, Message: err.Error()})
+	}
+
+	body, contentType, err := buildAPIPayload(cmd, parsed)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	if method == "" {
+		if len(body) > 0 {
+			method = http.MethodPost
+		} else {
+			method = http.MethodGet
+		}
+	}
+
+	client, err := newClientForCommand(cmd)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+
+	if apiVerbose(cmd) {
+		printAPIRequestDebug(cmd, method, path, parsed.Headers, body, contentType)
+	}
+
+	resp, err := client.Raw(cmd.Context(), notion.RawRequest{
+		Method:      method,
+		Path:        path,
+		Query:       parsed.Query,
+		Headers:     parsed.Headers,
+		Body:        body,
+		ContentType: contentType,
+	})
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	if apiVerbose(cmd) {
+		printAPIResponseDebug(cmd, resp)
+	}
+	return printAPIResponse(cmd, resp, start)
+}
+
+func printAPISpec(cmd *cobra.Command, path, method string, methodExplicit bool) error {
+	endpoint, err := findCatalogEndpoint(path, method, methodExplicit)
+	if err != nil {
+		return handleError(cmd, &clierrors.NotionCLIError{Code: clierrors.CodeNotFound, Message: err.Error()})
+	}
+	b, err := endpointSpecJSON(endpoint)
+	if err != nil {
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Failed to render endpoint spec", err))
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(b))
+	return nil
+}
+
+func printAPIDocs(cmd *cobra.Command, path, method string, methodExplicit bool) error {
+	endpoint, err := findCatalogEndpoint(path, method, methodExplicit)
+	if err != nil {
+		return handleError(cmd, &clierrors.NotionCLIError{Code: clierrors.CodeNotFound, Message: err.Error()})
+	}
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), endpoint.Docs)
+	return nil
+}
+
+func buildAPIPayload(cmd *cobra.Command, parsed *parsedAPIInline) ([]byte, string, error) {
+	data, _ := cmd.Flags().GetString("data")
+	filePath, _ := cmd.Flags().GetString("file")
+	hasInlineBody := len(parsed.BodyFields) > 0
+	stdinBody, stdinHasBody, err := readAPIStdin(cmd)
+	if err != nil {
+		return nil, "", err
+	}
+
+	bodySources := 0
+	if strings.TrimSpace(data) != "" {
+		bodySources++
+	}
+	if stdinHasBody {
+		bodySources++
+	}
+	if hasInlineBody && filePath == "" {
+		bodySources++
+	}
+	if filePath != "" {
+		bodySources++
+	}
+	if bodySources > 1 {
+		return nil, "", &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInvalidRequest,
+			Message: "Use only one request body source: stdin JSON, --data, inline body fields, or --file",
+		}
+	}
+
+	switch {
+	case filePath != "":
+		formFields, err := apiFieldsAsFormFields(parsed.BodyFields)
+		if err != nil {
+			return nil, "", clierrors.Wrap(clierrors.CodeInvalidRequest, "Invalid multipart form fields", err)
+		}
+		return buildAPIMultipart(filePath, formFields)
+	case strings.TrimSpace(data) != "":
+		if err := validateJSONBody([]byte(data)); err != nil {
+			return nil, "", err
+		}
+		return []byte(data), "application/json", nil
+	case stdinHasBody:
+		if err := validateJSONBody(stdinBody); err != nil {
+			return nil, "", err
+		}
+		return stdinBody, "application/json", nil
+	case hasInlineBody:
+		body, err := buildAPIBody(parsed.BodyFields)
+		if err != nil {
+			return nil, "", &clierrors.NotionCLIError{Code: clierrors.CodeInvalidRequest, Message: err.Error()}
+		}
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, "", clierrors.Wrap(clierrors.CodeInternalError, "Failed to encode request body", err)
+		}
+		return b, "application/json", nil
+	default:
+		return nil, "", nil
+	}
+}
+
+func readAPIStdin(cmd *cobra.Command) ([]byte, bool, error) {
+	in := cmd.InOrStdin()
+	if file, ok := in.(*os.File); ok {
+		stat, err := file.Stat()
+		if err != nil {
+			return nil, false, clierrors.Wrap(clierrors.CodeInternalError, "Failed to stat stdin", err)
+		}
+		if stat.Mode()&os.ModeCharDevice != 0 {
+			return nil, false, nil
+		}
+	}
+	b, err := io.ReadAll(in)
+	if err != nil {
+		return nil, false, clierrors.Wrap(clierrors.CodeInternalError, "Failed to read stdin", err)
+	}
+	if strings.TrimSpace(string(b)) == "" {
+		return nil, false, nil
+	}
+	return b, true, nil
+}
+
+func validateJSONBody(body []byte) error {
+	var v any
+	if err := json.Unmarshal(body, &v); err != nil {
+		return clierrors.InvalidJSON(err.Error())
+	}
+	return nil
+}
+
+func buildAPIMultipart(path string, fields map[string]string) ([]byte, string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInvalidRequest,
+			Message: fmt.Sprintf("Cannot read file %q: %s", path, err),
+		}
+	}
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			return nil, "", clierrors.Wrap(clierrors.CodeInternalError, "Failed to write multipart field", err)
+		}
+	}
+	part, err := mw.CreateFormFile("file", filepath.Base(path))
+	if err != nil {
+		return nil, "", clierrors.Wrap(clierrors.CodeInternalError, "Failed to create multipart file field", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return nil, "", clierrors.Wrap(clierrors.CodeInternalError, "Failed to write multipart file bytes", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, "", clierrors.Wrap(clierrors.CodeInternalError, "Failed to close multipart body", err)
+	}
+	return buf.Bytes(), mw.FormDataContentType(), nil
+}
+
+func printAPIResponse(cmd *cobra.Command, resp *notion.RawResponse, start time.Time) error {
+	if outputFormatExplicit(cmd) && outputFormat(cmd) != output.FormatRaw {
+		var decoded any
+		if len(resp.Body) > 0 {
+			if err := json.Unmarshal(resp.Body, &decoded); err != nil {
+				decoded = string(resp.Body)
+			}
+		} else {
+			decoded = map[string]any{}
+		}
+		p := output.NewPrinter(outputFormat(cmd))
+		p.Writer = cmd.OutOrStdout()
+		p.PrintSuccess(decoded, "api", start)
+		return nil
+	}
+	if len(resp.Body) > 0 {
+		_, _ = cmd.OutOrStdout().Write(resp.Body)
+		if resp.Body[len(resp.Body)-1] != '\n' {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout())
+		}
+	}
+	return nil
+}
+
+func apiVerbose(cmd *cobra.Command) bool {
+	v, _ := cmd.Flags().GetBool("verbose")
+	return v
+}
+
+func printAPIRequestDebug(cmd *cobra.Command, method, path string, headers http.Header, body []byte, contentType string) {
+	unsafe, _ := cmd.Flags().GetBool("unsafe-verbose")
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "> %s %s\n", method, path)
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "> Authorization:", redactedAuth(unsafe))
+	if version, _ := cmd.Flags().GetString("notion-version"); version != "" {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "> Notion-Version:", version)
+	}
+	if contentType != "" {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "> Content-Type:", contentType)
+	}
+	for k, values := range headers {
+		for _, v := range values {
+			if strings.EqualFold(k, "Authorization") && !unsafe {
+				v = "<redacted>"
+			}
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "> %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "> Body: %s\n", string(body))
+	}
+}
+
+func printAPIResponseDebug(cmd *cobra.Command, resp *notion.RawResponse) {
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "< Status: %d\n", resp.StatusCode)
+	for k, values := range resp.Headers {
+		for _, v := range values {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "< %s: %s\n", k, v)
+		}
+	}
+	if len(resp.Body) > 0 {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "< Body: %s\n", string(resp.Body))
+	}
+}
+
+func redactedAuth(unsafe bool) string {
+	if unsafe {
+		return "<not redacted>"
+	}
+	return "<redacted>"
+}

--- a/internal/cli/commands/api_catalog.go
+++ b/internal/cli/commands/api_catalog.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type apiCatalogEndpoint struct {
+	Method  string         `json:"method"`
+	Path    string         `json:"path"`
+	Summary string         `json:"summary"`
+	Spec    map[string]any `json:"spec"`
+	Docs    string         `json:"docs"`
+}
+
+var apiCatalog = []apiCatalogEndpoint{
+	catalogEndpoint("GET", "v1/users", "List users"),
+	catalogEndpoint("GET", "v1/users/me", "Retrieve bot user"),
+	catalogEndpoint("GET", "v1/users/{user_id}", "Retrieve a user"),
+	catalogEndpoint("POST", "v1/search", "Search pages and data sources"),
+	catalogEndpoint("POST", "v1/pages", "Create a page"),
+	catalogEndpoint("GET", "v1/pages/{page_id}", "Retrieve a page"),
+	catalogEndpoint("PATCH", "v1/pages/{page_id}", "Update page properties, icon, cover, or trash state"),
+	catalogEndpoint("GET", "v1/pages/{page_id}/properties/{property_id}", "Retrieve a page property item"),
+	catalogEndpoint("GET", "v1/pages/{page_id}/markdown", "Retrieve page content as enhanced markdown"),
+	catalogEndpoint("PATCH", "v1/pages/{page_id}/markdown", "Update page content from enhanced markdown"),
+	catalogEndpoint("POST", "v1/pages/{page_id}/move", "Move a page to a new parent"),
+	catalogEndpoint("GET", "v1/blocks/{block_id}", "Retrieve a block"),
+	catalogEndpoint("PATCH", "v1/blocks/{block_id}", "Update a block"),
+	catalogEndpoint("DELETE", "v1/blocks/{block_id}", "Delete a block"),
+	catalogEndpoint("GET", "v1/blocks/{block_id}/children", "List block children"),
+	catalogEndpoint("PATCH", "v1/blocks/{block_id}/children", "Append block children"),
+	catalogEndpoint("GET", "v1/databases/{database_id}", "Retrieve database metadata"),
+	catalogEndpoint("PATCH", "v1/databases/{database_id}", "Update a database"),
+	catalogEndpoint("POST", "v1/databases", "Create a database"),
+	catalogEndpoint("POST", "v1/databases/{database_id}/query", "Query a database"),
+	catalogEndpoint("GET", "v1/data_sources/{data_source_id}", "Retrieve a data source"),
+	catalogEndpoint("PATCH", "v1/data_sources/{data_source_id}", "Update a data source"),
+	catalogEndpoint("POST", "v1/data_sources", "Create a data source"),
+	catalogEndpoint("POST", "v1/data_sources/{data_source_id}/query", "Query a data source"),
+	catalogEndpoint("GET", "v1/data_sources/{data_source_id}/templates", "List data source templates"),
+	catalogEndpoint("PATCH", "v1/data_sources/{data_source_id}/properties", "Update data source properties"),
+	catalogEndpoint("POST", "v1/comments", "Create a comment"),
+	catalogEndpoint("GET", "v1/comments", "List comments"),
+	catalogEndpoint("GET", "v1/comments/{comment_id}", "Retrieve a comment"),
+	catalogEndpoint("PATCH", "v1/comments/{comment_id}", "Update a comment"),
+	catalogEndpoint("DELETE", "v1/comments/{comment_id}", "Delete a comment"),
+	catalogEndpoint("GET", "v1/file_uploads", "List file uploads"),
+	catalogEndpoint("POST", "v1/file_uploads", "Create a file upload"),
+	catalogEndpoint("GET", "v1/file_uploads/{file_upload_id}", "Retrieve a file upload"),
+	catalogEndpoint("POST", "v1/file_uploads/{file_upload_id}/send", "Send file upload bytes"),
+	catalogEndpoint("POST", "v1/file_uploads/{file_upload_id}/complete", "Complete a multipart file upload"),
+	catalogEndpoint("GET", "v1/views", "List views"),
+	catalogEndpoint("POST", "v1/views", "Create a view"),
+	catalogEndpoint("GET", "v1/views/{view_id}", "Retrieve a view"),
+	catalogEndpoint("PATCH", "v1/views/{view_id}", "Update a view"),
+	catalogEndpoint("DELETE", "v1/views/{view_id}", "Delete a view"),
+	catalogEndpoint("POST", "v1/views/{view_id}/queries", "Create a cached view query"),
+	catalogEndpoint("GET", "v1/views/{view_id}/queries/{query_id}", "Retrieve cached view query results"),
+	catalogEndpoint("DELETE", "v1/views/{view_id}/queries/{query_id}", "Delete a cached view query"),
+	catalogEndpoint("GET", "v1/custom_emojis", "List custom emojis"),
+	catalogEndpoint("GET", "v1/custom_emojis/{custom_emoji_id}", "Retrieve a custom emoji"),
+}
+
+func catalogEndpoint(method, path, summary string) apiCatalogEndpoint {
+	return apiCatalogEndpoint{
+		Method:  method,
+		Path:    path,
+		Summary: summary,
+		Spec: map[string]any{
+			"method":      method,
+			"path":        "/" + path,
+			"summary":     summary,
+			"description": "Reduced embedded endpoint fragment for offline notion-cli api introspection.",
+		},
+		Docs: fmt.Sprintf("# %s %s\n\n%s\n\nThis offline help is generated from notion-cli's embedded public API catalog. For the complete current reference, use https://developers.notion.com/reference.\n", method, "/"+path, summary),
+	}
+}
+
+func apiCatalogRows() []map[string]any {
+	rows := make([]map[string]any, len(apiCatalog))
+	for i, endpoint := range apiCatalog {
+		rows[i] = map[string]any{
+			"method":  endpoint.Method,
+			"path":    endpoint.Path,
+			"summary": endpoint.Summary,
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		pi, _ := rows[i]["path"].(string)
+		pj, _ := rows[j]["path"].(string)
+		if pi == pj {
+			mi, _ := rows[i]["method"].(string)
+			mj, _ := rows[j]["method"].(string)
+			return mi < mj
+		}
+		return pi < pj
+	})
+	return rows
+}
+
+func findCatalogEndpoint(path, method string, explicitMethod bool) (*apiCatalogEndpoint, error) {
+	path = normalizeAPIPathForCatalog(path)
+	method = strings.ToUpper(strings.TrimSpace(method))
+	var matches []apiCatalogEndpoint
+	for _, endpoint := range apiCatalog {
+		if endpoint.Path == path {
+			matches = append(matches, endpoint)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no embedded API catalog entry for %s", path)
+	}
+	if method == "" || !explicitMethod {
+		if len(matches) > 1 {
+			var methods []string
+			for _, match := range matches {
+				methods = append(methods, match.Method)
+			}
+			sort.Strings(methods)
+			return nil, fmt.Errorf("method is ambiguous for %s; pass -X with one of: %s", path, strings.Join(methods, ", "))
+		}
+		return &matches[0], nil
+	}
+	for _, match := range matches {
+		if match.Method == method {
+			return &match, nil
+		}
+	}
+	return nil, fmt.Errorf("no embedded API catalog entry for %s %s", method, path)
+}
+
+func normalizeAPIPathForCatalog(path string) string {
+	path = strings.TrimSpace(strings.TrimLeft(path, "/"))
+	if !strings.HasPrefix(path, "v1/") {
+		path = "v1/" + path
+	}
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		path = path[:idx]
+	}
+	return path
+}
+
+func endpointSpecJSON(endpoint *apiCatalogEndpoint) ([]byte, error) {
+	return json.MarshalIndent(endpoint.Spec, "", "  ")
+}

--- a/internal/cli/commands/api_parser.go
+++ b/internal/cli/commands/api_parser.go
@@ -1,0 +1,243 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type apiInlineField struct {
+	Path  string
+	Value any
+}
+
+type parsedAPIInline struct {
+	BodyFields []apiInlineField
+	Query      url.Values
+	Headers    http.Header
+}
+
+type apiPathPart struct {
+	Key    string
+	Index  *int
+	Append bool
+}
+
+func parseAPIInlineArgs(args []string) (*parsedAPIInline, error) {
+	parsed := &parsedAPIInline{
+		Query:   url.Values{},
+		Headers: http.Header{},
+	}
+	for _, arg := range args {
+		switch {
+		case strings.Contains(arg, "=="):
+			key, value, _ := strings.Cut(arg, "==")
+			if strings.TrimSpace(key) == "" {
+				return nil, fmt.Errorf("query parameter %q is missing a name", arg)
+			}
+			parsed.Query.Add(key, value)
+		case strings.Contains(arg, ":="):
+			path, raw, _ := strings.Cut(arg, ":=")
+			if strings.TrimSpace(path) == "" {
+				return nil, fmt.Errorf("body field %q is missing a path", arg)
+			}
+			var value any
+			if err := json.Unmarshal([]byte(raw), &value); err != nil {
+				return nil, fmt.Errorf("body field %q has invalid JSON value: %w", path, err)
+			}
+			parsed.BodyFields = append(parsed.BodyFields, apiInlineField{Path: path, Value: value})
+		case looksLikeHeaderArg(arg):
+			name, value, _ := strings.Cut(arg, ":")
+			if strings.TrimSpace(name) == "" {
+				return nil, fmt.Errorf("header %q is missing a name", arg)
+			}
+			parsed.Headers.Add(name, value)
+		case strings.Contains(arg, "="):
+			path, value, _ := strings.Cut(arg, "=")
+			if strings.TrimSpace(path) == "" {
+				return nil, fmt.Errorf("body field %q is missing a path", arg)
+			}
+			parsed.BodyFields = append(parsed.BodyFields, apiInlineField{Path: path, Value: value})
+		default:
+			return nil, fmt.Errorf("cannot parse inline argument %q", arg)
+		}
+	}
+	return parsed, nil
+}
+
+func looksLikeHeaderArg(arg string) bool {
+	colon := strings.Index(arg, ":")
+	if colon <= 0 {
+		return false
+	}
+	if strings.Contains(arg, ":=") {
+		return false
+	}
+	eq := strings.Index(arg, "=")
+	return eq == -1 || colon < eq
+}
+
+func buildAPIBody(fields []apiInlineField) (map[string]any, error) {
+	body := map[string]any{}
+	for _, field := range fields {
+		parts, err := parseAPIPath(field.Path)
+		if err != nil {
+			return nil, err
+		}
+		if len(parts) == 0 || parts[0].Key == "" {
+			return nil, fmt.Errorf("body field path %q must start with an object key", field.Path)
+		}
+		next, err := setAPIPathValue(body, parts, field.Value)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", field.Path, err)
+		}
+		var ok bool
+		body, ok = next.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("body field path %q cannot replace the root object", field.Path)
+		}
+	}
+	return body, nil
+}
+
+func apiFieldsAsFormFields(fields []apiInlineField) (map[string]string, error) {
+	form := map[string]string{}
+	for _, field := range fields {
+		switch v := field.Value.(type) {
+		case string:
+			form[field.Path] = v
+		default:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			form[field.Path] = string(b)
+		}
+	}
+	return form, nil
+}
+
+func parseAPIPath(path string) ([]apiPathPart, error) {
+	var parts []apiPathPart
+	var token strings.Builder
+	for i := 0; i < len(path); i++ {
+		switch path[i] {
+		case '.':
+			if token.Len() > 0 {
+				parts = append(parts, apiPathPart{Key: token.String()})
+				token.Reset()
+			}
+		case '[':
+			if token.Len() > 0 {
+				parts = append(parts, apiPathPart{Key: token.String()})
+				token.Reset()
+			}
+			end := strings.IndexByte(path[i+1:], ']')
+			if end < 0 {
+				return nil, fmt.Errorf("unclosed bracket in path %q", path)
+			}
+			raw := path[i+1 : i+1+end]
+			switch {
+			case raw == "":
+				parts = append(parts, apiPathPart{Append: true})
+			case isDigits(raw):
+				idx, _ := strconv.Atoi(raw)
+				parts = append(parts, apiPathPart{Index: &idx})
+			default:
+				parts = append(parts, apiPathPart{Key: raw})
+			}
+			i += end + 1
+		default:
+			token.WriteByte(path[i])
+		}
+	}
+	if token.Len() > 0 {
+		parts = append(parts, apiPathPart{Key: token.String()})
+	}
+	return parts, nil
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func setAPIPathValue(node any, parts []apiPathPart, value any) (any, error) {
+	if len(parts) == 0 {
+		return value, nil
+	}
+	part := parts[0]
+	rest := parts[1:]
+	switch {
+	case part.Key != "":
+		m, ok := node.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected object before %q", part.Key)
+		}
+		child, exists := m[part.Key]
+		if !exists || child == nil {
+			child = newAPIContainer(rest)
+		}
+		next, err := setAPIPathValue(child, rest, value)
+		if err != nil {
+			return nil, err
+		}
+		m[part.Key] = next
+		return m, nil
+	case part.Index != nil:
+		s, ok := node.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected array before index %d", *part.Index)
+		}
+		idx := *part.Index
+		for len(s) <= idx {
+			s = append(s, nil)
+		}
+		child := s[idx]
+		if child == nil {
+			child = newAPIContainer(rest)
+		}
+		next, err := setAPIPathValue(child, rest, value)
+		if err != nil {
+			return nil, err
+		}
+		s[idx] = next
+		return s, nil
+	case part.Append:
+		s, ok := node.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected array before append")
+		}
+		if len(rest) == 0 {
+			return append(s, value), nil
+		}
+		child := newAPIContainer(rest)
+		next, err := setAPIPathValue(child, rest, value)
+		if err != nil {
+			return nil, err
+		}
+		return append(s, next), nil
+	default:
+		return nil, fmt.Errorf("empty path segment")
+	}
+}
+
+func newAPIContainer(parts []apiPathPart) any {
+	if len(parts) == 0 {
+		return nil
+	}
+	if parts[0].Key != "" {
+		return map[string]any{}
+	}
+	return []any{}
+}

--- a/internal/cli/commands/api_parser_test.go
+++ b/internal/cli/commands/api_parser_test.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestParseAPIInlineArgs_BodyQueryAndHeader(t *testing.T) {
+	parsed, err := parseAPIInlineArgs([]string{
+		"query=roadmap",
+		"page_size:=10",
+		"start_cursor==abc",
+		"Accept:application/json",
+	})
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if got := parsed.Query.Get("start_cursor"); got != "abc" {
+		t.Fatalf("query start_cursor = %q", got)
+	}
+	if got := parsed.Headers.Get("Accept"); got != "application/json" {
+		t.Fatalf("Accept header = %q", got)
+	}
+	body, err := buildAPIBody(parsed.BodyFields)
+	if err != nil {
+		t.Fatalf("build body failed: %v", err)
+	}
+	if body["query"] != "roadmap" {
+		t.Fatalf("query body = %#v", body["query"])
+	}
+	if body["page_size"] != float64(10) {
+		t.Fatalf("page_size body = %#v", body["page_size"])
+	}
+}
+
+func TestBuildAPIBody_NestedBracketDotAndAppend(t *testing.T) {
+	parsed, err := parseAPIInlineArgs([]string{
+		"parent[page_id]=abc123",
+		"properties.Name.title[0].text.content=Meeting notes",
+		"rich_text[][text][content]=First",
+		"rich_text[][text][content]=Second",
+		"filter:={\"property\":\"object\",\"value\":\"page\"}",
+	})
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	body, err := buildAPIBody(parsed.BodyFields)
+	if err != nil {
+		t.Fatalf("build body failed: %v", err)
+	}
+	b, _ := json.Marshal(body)
+	var got map[string]any
+	_ = json.Unmarshal(b, &got)
+
+	parent := got["parent"].(map[string]any)
+	if parent["page_id"] != "abc123" {
+		t.Fatalf("parent = %#v", parent)
+	}
+	props := got["properties"].(map[string]any)
+	name := props["Name"].(map[string]any)
+	title := name["title"].([]any)
+	text := title[0].(map[string]any)["text"].(map[string]any)
+	if text["content"] != "Meeting notes" {
+		t.Fatalf("nested title content = %#v", text["content"])
+	}
+	richText := got["rich_text"].([]any)
+	if len(richText) != 2 {
+		t.Fatalf("rich_text len = %d", len(richText))
+	}
+	filter := got["filter"].(map[string]any)
+	if filter["value"] != "page" {
+		t.Fatalf("typed filter = %#v", filter)
+	}
+}
+
+func TestAPIFieldsAsFormFields_JSONValues(t *testing.T) {
+	fields, err := apiFieldsAsFormFields([]apiInlineField{
+		{Path: "part_number", Value: float64(1)},
+		{Path: "name", Value: "chunk"},
+	})
+	if err != nil {
+		t.Fatalf("form fields failed: %v", err)
+	}
+	want := map[string]string{"part_number": "1", "name": "chunk"}
+	if !reflect.DeepEqual(fields, want) {
+		t.Fatalf("fields = %#v, want %#v", fields, want)
+	}
+}
+
+func TestLooksLikeHeaderArg(t *testing.T) {
+	if !looksLikeHeaderArg("X-Trace-Id:abc") {
+		t.Fatal("expected header arg")
+	}
+	if looksLikeHeaderArg("filter:={\"a\":1}") {
+		t.Fatal("typed body arg should not be a header")
+	}
+	if looksLikeHeaderArg("query==roadmap") {
+		t.Fatal("query arg should not be a header")
+	}
+}
+
+func TestParseAPIInlineArgs_RepeatedHeaders(t *testing.T) {
+	parsed, err := parseAPIInlineArgs([]string{"X-Test:a", "X-Test:b"})
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if got := parsed.Headers.Values("X-Test"); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("headers = %#v", got)
+	}
+	if parsed.Headers.Get("X-Test") == "" || parsed.Headers.Get(http.CanonicalHeaderKey("X-Test")) == "" {
+		t.Fatalf("header canonicalization failed: %#v", parsed.Headers)
+	}
+}

--- a/internal/cli/commands/api_test.go
+++ b/internal/cli/commands/api_test.go
@@ -1,0 +1,232 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func runAPIRoot(t *testing.T, input io.Reader, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "notion-cli", SilenceErrors: true, SilenceUsage: true}
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().String("notion-version", "", "")
+	RegisterAPICommands(root)
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	if input != nil {
+		root.SetIn(input)
+	}
+	root.SetArgs(args)
+	err := root.Execute()
+	return &out, &errBuf, err
+}
+
+func withAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("NOTION_TOKEN", "secret_test_token")
+	t.Setenv("NOTION_API_TOKEN", "")
+	t.Setenv("NOTION_CLI_BASE_URL", srv.URL)
+	t.Setenv("NOTION_API_VERSION", "")
+	return srv
+}
+
+func TestAPICommand_DefaultPostWithInlineBody(t *testing.T) {
+	var gotBody map[string]any
+	srv := withAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/search" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer secret_test_token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	defer srv.Close()
+
+	out, _, err := runAPIRoot(t, nil, "api", "v1/search", "query=roadmap", "page_size:=10")
+	if err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+	if !strings.Contains(out.String(), `"ok":true`) {
+		t.Fatalf("raw output = %q", out.String())
+	}
+	if gotBody["query"] != "roadmap" || gotBody["page_size"] != float64(10) {
+		t.Fatalf("body = %#v", gotBody)
+	}
+}
+
+func TestAPICommand_DefaultGetWithoutBody(t *testing.T) {
+	srv := withAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/users/me" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": "user"})
+	})
+	defer srv.Close()
+
+	if _, _, err := runAPIRoot(t, nil, "api", "/v1/users/me"); err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+}
+
+func TestAPICommand_MethodQueryHeaderAndVersion(t *testing.T) {
+	srv := withAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Query()["filter_properties"] == nil || r.URL.Query().Get("page_size") != "10" {
+			t.Fatalf("query = %#v", r.URL.Query())
+		}
+		if r.Header.Get("X-Trace-Id") != "cli-test" {
+			t.Fatalf("X-Trace-Id = %q", r.Header.Get("X-Trace-Id"))
+		}
+		if r.Header.Get("Notion-Version") != "2026-03-11" {
+			t.Fatalf("Notion-Version = %q", r.Header.Get("Notion-Version"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	defer srv.Close()
+	t.Setenv("NOTION_API_VERSION", "2026-03-11")
+
+	_, _, err := runAPIRoot(t, nil,
+		"api", "v1/pages/abc",
+		"-X", "PATCH",
+		"archived:=true",
+		"page_size==10",
+		"filter_properties==Name",
+		"X-Trace-Id:cli-test",
+	)
+	if err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+}
+
+func TestAPICommand_DataAndInlineConflict(t *testing.T) {
+	_, _, err := runAPIRoot(t, nil, "api", "v1/search", "--data", `{"query":"x"}`, "page_size:=1")
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+}
+
+func TestAPICommand_FileMultipart(t *testing.T) {
+	tmp := t.TempDir() + "/chunk.txt"
+	if err := os.WriteFile(tmp, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv := withAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("multipart reader: %v", err)
+		}
+		gotPartNumber := false
+		gotFile := false
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("next part: %v", err)
+			}
+			data, _ := io.ReadAll(part)
+			switch part.FormName() {
+			case "part_number":
+				gotPartNumber = string(data) == "1"
+			case "file":
+				gotFile = part.FileName() == "chunk.txt" && string(data) == "hello"
+			}
+		}
+		if !gotPartNumber || !gotFile {
+			t.Fatalf("multipart fields missing: part=%v file=%v", gotPartNumber, gotFile)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	defer srv.Close()
+
+	_, _, err := runAPIRoot(t, nil, "api", "v1/file_uploads/up/send", "--file", tmp, "part_number:=1")
+	if err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+}
+
+func TestAPICommand_LSSpecDocs(t *testing.T) {
+	out, _, err := runAPIRoot(t, nil, "api", "ls", "--json")
+	if err != nil {
+		t.Fatalf("api ls failed: %v", err)
+	}
+	if !strings.Contains(out.String(), `"path": "v1/search"`) {
+		t.Fatalf("api ls output missing search: %s", out.String())
+	}
+
+	out, _, err = runAPIRoot(t, nil, "api", "v1/search", "--spec", "-X", "POST")
+	if err != nil {
+		t.Fatalf("api spec failed: %v", err)
+	}
+	if !strings.Contains(out.String(), `"method": "POST"`) {
+		t.Fatalf("spec output = %s", out.String())
+	}
+
+	out, _, err = runAPIRoot(t, nil, "api", "v1/search", "--docs", "-X", "POST")
+	if err != nil {
+		t.Fatalf("api docs failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "# POST /v1/search") {
+		t.Fatalf("docs output = %s", out.String())
+	}
+}
+
+func TestAPICommand_EnvTokenAlias(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer ntn_test_token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+	t.Setenv("NOTION_TOKEN", "")
+	t.Setenv("NOTION_API_TOKEN", "ntn_test_token")
+	t.Setenv("NOTION_CLI_BASE_URL", srv.URL)
+
+	if _, _, err := runAPIRoot(t, nil, "api", "v1/users/me"); err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+}
+
+func TestAPIVerboseRedactsAuthorization(t *testing.T) {
+	srv := withAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	defer srv.Close()
+
+	_, errBuf, err := runAPIRoot(t, nil, "api", "v1/users/me", "--verbose")
+	if err != nil {
+		t.Fatalf("api command failed: %v", err)
+	}
+	if strings.Contains(errBuf.String(), "secret_test_token") {
+		t.Fatalf("verbose output leaked token: %s", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "<redacted>") {
+		t.Fatalf("verbose output did not redact auth: %s", errBuf.String())
+	}
+}

--- a/internal/cli/commands/auth.go
+++ b/internal/cli/commands/auth.go
@@ -34,6 +34,18 @@ func RegisterAuthCommands(root *cobra.Command) {
 	root.AddCommand(authCmd)
 }
 
+// RegisterRootAuthAliases adds official ntn-style root login/logout aliases
+// while preserving the existing auth command group.
+func RegisterRootAuthAliases(root *cobra.Command) {
+	login := newAuthLoginCmd()
+	login.Use = "login"
+	login.Short = "Log in to Notion"
+	logout := newAuthLogoutCmd()
+	logout.Use = "logout [workspace]"
+	logout.Short = "Log out of Notion"
+	root.AddCommand(login, logout)
+}
+
 // --- auth login ---
 
 func newAuthLoginCmd() *cobra.Command {
@@ -257,10 +269,14 @@ func runAuthStatus(cmd *cobra.Command, args []string) error {
 
 	switch method {
 	case "env":
-		data["source"] = "NOTION_TOKEN environment variable"
+		source := "NOTION_TOKEN environment variable"
+		if os.Getenv("NOTION_TOKEN") == "" && os.Getenv("NOTION_API_TOKEN") != "" {
+			source = "NOTION_API_TOKEN environment variable"
+		}
+		data["source"] = source
 		data["token"] = maskToken(cfg.Token)
 		if cfg.HasOAuthToken() || (!active.Legacy && active.Metadata != nil) {
-			data["note"] = "Stored workspace credential is also configured but NOTION_TOKEN takes precedence"
+			data["note"] = "Stored workspace credential is also configured but environment token takes precedence"
 		}
 	case "oauth":
 		data["workspace_id"] = cfg.OAuthWorkspaceID
@@ -280,7 +296,7 @@ func runAuthStatus(cmd *cobra.Command, args []string) error {
 		data["message"] = "Not authenticated"
 		data["suggestions"] = []string{
 			"Run 'notion-cli auth login' to authenticate via OAuth",
-			"Or set NOTION_TOKEN environment variable",
+			"Or set NOTION_TOKEN / NOTION_API_TOKEN environment variable",
 		}
 	}
 

--- a/internal/cli/commands/config_cmd.go
+++ b/internal/cli/commands/config_cmd.go
@@ -204,6 +204,7 @@ func runConfigList(cmd *cobra.Command, args []string) error {
 		"oauth_access_token":  maskToken(cfg.OAuthAccessToken),
 		"oauth_refresh_token": maskToken(cfg.OAuthRefreshToken),
 		"base_url":            cfg.BaseURL,
+		"notion_version":      cfg.NotionVersion,
 		"max_retries":         cfg.MaxRetries,
 		"base_delay_ms":       cfg.BaseDelayMs,
 		"max_delay_ms":        cfg.MaxDelayMs,
@@ -227,6 +228,8 @@ func configValue(cfg *config.Config, key string) string {
 		return cfg.Token
 	case "base_url":
 		return cfg.BaseURL
+	case "notion_version":
+		return cfg.NotionVersion
 	case "max_retries":
 		return fmt.Sprintf("%d", cfg.MaxRetries)
 	case "base_delay_ms":

--- a/internal/cli/commands/data_source.go
+++ b/internal/cli/commands/data_source.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	clierrors "github.com/Coastal-Programs/notion-cli/v6/internal/errors"
@@ -20,7 +22,7 @@ import (
 func RegisterDataSourceCommands(root *cobra.Command) {
 	dsCmd := &cobra.Command{
 		Use:     "data-source",
-		Aliases: []string{"ds", "data_source", "datasource"},
+		Aliases: []string{"ds", "data_source", "datasource", "datasources"},
 		Short:   "Data source operations (Notion API 2025-09-03)",
 		Long: "Retrieve, create, update, and query Notion data sources. " +
 			"Each Notion database has one or more data sources; these commands address them directly.",
@@ -31,6 +33,7 @@ func RegisterDataSourceCommands(root *cobra.Command) {
 		newDataSourceCreateCmd(),
 		newDataSourceUpdateCmd(),
 		newDataSourceQueryCmd(),
+		newDataSourceResolveCmd(),
 		newDataSourceTemplatesCmd(),
 		newDataSourcePropertiesCmd(),
 	)
@@ -238,8 +241,11 @@ func newDataSourceQueryCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String("filter", "", "Filter as JSON string")
+	cmd.Flags().String("filter-file", "", "Read filter JSON from a file, or '-' for stdin")
 	cmd.Flags().String("sorts", "", "Sorts as JSON array")
+	cmd.Flags().StringArrayP("sort", "s", nil, "Sort spec: '<property> [asc|desc]' (repeatable)")
 	cmd.Flags().Int("page-size", 0, "Number of results per page (1-100)")
+	cmd.Flags().Int("limit", 0, "Number of results per page (official ntn alias)")
 	cmd.Flags().String("start-cursor", "", "Pagination cursor")
 	addOutputFlags(cmd)
 
@@ -261,7 +267,26 @@ func runDataSourceQuery(cmd *cobra.Command, args []string) error {
 
 	body := map[string]any{}
 
-	if f, _ := cmd.Flags().GetString("filter"); f != "" {
+	if filterFile, _ := cmd.Flags().GetString("filter-file"); filterFile != "" {
+		var data []byte
+		var readErr error
+		if filterFile == "-" {
+			data, readErr = io.ReadAll(cmd.InOrStdin())
+		} else {
+			data, readErr = os.ReadFile(filterFile)
+		}
+		if readErr != nil {
+			return handleError(cmd, &clierrors.NotionCLIError{
+				Code:    clierrors.CodeInvalidRequest,
+				Message: fmt.Sprintf("Cannot read filter file: %s", readErr),
+			})
+		}
+		var filter map[string]any
+		if err := json.Unmarshal(data, &filter); err != nil {
+			return handleError(cmd, clierrors.InvalidJSON(fmt.Sprintf("--filter-file: %s", err)))
+		}
+		body["filter"] = filter
+	} else if f, _ := cmd.Flags().GetString("filter"); f != "" {
 		var filter map[string]any
 		if err := json.Unmarshal([]byte(f), &filter); err != nil {
 			return handleError(cmd, clierrors.InvalidJSON(fmt.Sprintf("--filter: %s", err)))
@@ -276,6 +301,17 @@ func runDataSourceQuery(cmd *cobra.Command, args []string) error {
 		}
 		body["sorts"] = sorts
 	}
+	if sortSpecs, _ := cmd.Flags().GetStringArray("sort"); len(sortSpecs) > 0 {
+		sorts := make([]map[string]any, 0, len(sortSpecs))
+		for _, spec := range sortSpecs {
+			property, direction := parseSortSpec(spec)
+			sorts = append(sorts, map[string]any{
+				"property":  property,
+				"direction": direction,
+			})
+		}
+		body["sorts"] = sorts
+	}
 
 	if ps, _ := cmd.Flags().GetInt("page-size"); ps > 0 {
 		if ps > 100 {
@@ -285,6 +321,15 @@ func runDataSourceQuery(cmd *cobra.Command, args []string) error {
 			})
 		}
 		body["page_size"] = ps
+	}
+	if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
+		if limit > 100 {
+			return handleError(cmd, &clierrors.NotionCLIError{
+				Code:    clierrors.CodeInvalidRequest,
+				Message: fmt.Sprintf("--limit must be between 1 and 100, got %d", limit),
+			})
+		}
+		body["page_size"] = limit
 	}
 
 	if c, _ := cmd.Flags().GetString("start-cursor"); c != "" {
@@ -298,6 +343,69 @@ func runDataSourceQuery(cmd *cobra.Command, args []string) error {
 
 	p := output.NewPrinter(outputFormat(cmd))
 	p.PrintSuccess(result, "data-source query", start)
+	return nil
+}
+
+func parseSortSpec(spec string) (property, direction string) {
+	fields := strings.Fields(spec)
+	if len(fields) == 0 {
+		return spec, "ascending"
+	}
+	property = strings.Join(fields, " ")
+	direction = "ascending"
+	last := strings.ToLower(fields[len(fields)-1])
+	if len(fields) > 1 && (last == "asc" || last == "ascending" || last == "desc" || last == "descending") {
+		property = strings.Join(fields[:len(fields)-1], " ")
+		if last == "desc" || last == "descending" {
+			direction = "descending"
+		}
+	}
+	return property, direction
+}
+
+// --- data-source resolve ---
+
+func newDataSourceResolveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve <database_id>",
+		Short: "Resolve a database to data source IDs",
+		Long:  "Resolve a Notion database ID to the data source IDs returned by the database metadata.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDataSourceResolve,
+	}
+	addOutputFlags(cmd)
+	return cmd
+}
+
+func runDataSourceResolve(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+	client, err := newClientForCommand(cmd)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	dbID, err := resolveID(args[0])
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	result, err := client.DatabaseRetrieve(cmd.Context(), dbID)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	rawSources, _ := result["data_sources"].([]any)
+	ids := make([]string, 0, len(rawSources))
+	for _, raw := range rawSources {
+		if m, ok := raw.(map[string]any); ok {
+			if id, _ := m["id"].(string); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	p := output.NewPrinter(outputFormat(cmd))
+	p.PrintSuccess(map[string]any{
+		"database_id":     dbID,
+		"data_source_ids": ids,
+		"data_sources":    rawSources,
+	}, "data-source resolve", start)
 	return nil
 }
 

--- a/internal/cli/commands/db.go
+++ b/internal/cli/commands/db.go
@@ -21,14 +21,14 @@ import (
 
 func newClientForCommand(cmd *cobra.Command) (*notion.Client, error) {
 	workspaceSlug := authWorkspaceFromCommand(cmd)
-	client, err := newClientForWorkspace(workspaceSlug)
+	client, err := newClientForWorkspaceAndCommand(workspaceSlug, cmd)
 	if !shouldRunInitialSetup(workspaceSlug, err) {
 		return client, err
 	}
 	if err := runInitialWorkspaceSetup(cmd); err != nil {
 		return nil, err
 	}
-	return newClientForWorkspace(workspaceSlug)
+	return newClientForWorkspaceAndCommand(workspaceSlug, cmd)
 }
 
 // newClientForWorkspace creates a Notion API client using the following precedence:
@@ -36,6 +36,10 @@ func newClientForCommand(cmd *cobra.Command) (*notion.Client, error) {
 //  2. OAuth access token from selected workspace credentials
 //  3. Legacy config token when the default workspace is explicitly selected
 func newClientForWorkspace(workspaceSlug string) (*notion.Client, error) {
+	return newClientForWorkspaceAndCommand(workspaceSlug, nil)
+}
+
+func newClientForWorkspaceAndCommand(workspaceSlug string, cmd *cobra.Command) (*notion.Client, error) {
 	// Always load config so we can apply tunable settings (base URL, retry,
 	// keep-alive) regardless of where the token comes from.
 	cfg, active, cfgErr := config.LoadConfigForWorkspace(workspaceSlug)
@@ -51,6 +55,9 @@ func newClientForWorkspace(workspaceSlug string) (*notion.Client, error) {
 	var opts []notion.ClientOption
 	if cfgErr == nil && cfg != nil {
 		opts = append(opts, clientOptionsForConfig(cfg)...)
+		if version := notionVersionForCommand(cmd, cfg); version != "" {
+			opts = append(opts, notion.WithNotionVersion(version))
+		}
 		// Pass config to client so it can auto-refresh OAuth tokens on 401.
 		if cfg.AuthMethod() == "oauth" && cfg.OAuthRefreshToken != "" {
 			opts = append(opts, notion.WithConfig(cfg))
@@ -62,6 +69,29 @@ func newClientForWorkspace(workspaceSlug string) (*notion.Client, error) {
 		}
 	}
 	return notion.NewClient(token, opts...), nil
+}
+
+func notionVersionForCommand(cmd *cobra.Command, cfg *config.Config) string {
+	if cmd != nil {
+		if flag := cmd.Flags().Lookup("notion-version"); flag != nil && flag.Changed {
+			v, _ := cmd.Flags().GetString("notion-version")
+			return strings.TrimSpace(v)
+		}
+		if flag := cmd.InheritedFlags().Lookup("notion-version"); flag != nil && flag.Changed {
+			v, _ := cmd.InheritedFlags().GetString("notion-version")
+			return strings.TrimSpace(v)
+		}
+		if cmd.Root() != nil {
+			if flag := cmd.Root().PersistentFlags().Lookup("notion-version"); flag != nil && flag.Changed {
+				v, _ := cmd.Root().PersistentFlags().GetString("notion-version")
+				return strings.TrimSpace(v)
+			}
+		}
+	}
+	if cfg != nil && strings.TrimSpace(cfg.NotionVersion) != "" {
+		return strings.TrimSpace(cfg.NotionVersion)
+	}
+	return ""
 }
 
 func maybeRefreshOAuthConfig(cfg *config.Config, active *config.ActiveWorkspace) {
@@ -108,6 +138,9 @@ func clientOptionsForConfig(cfg *config.Config) []notion.ClientOption {
 	var opts []notion.ClientOption
 	if cfg.BaseURL != "" {
 		opts = append(opts, notion.WithBaseURL(cfg.BaseURL))
+	}
+	if cfg.NotionVersion != "" {
+		opts = append(opts, notion.WithNotionVersion(cfg.NotionVersion))
 	}
 	opts = append(opts, notion.WithRetryConfig(retry.RetryConfig{
 		MaxRetries: cfg.MaxRetries,

--- a/internal/cli/commands/files.go
+++ b/internal/cli/commands/files.go
@@ -54,12 +54,100 @@ func RegisterFilesCommands(root *cobra.Command) {
 	}
 
 	filesCmd.AddCommand(
+		newFilesCreateCmd(),
 		newFilesUploadCmd(),
 		newFilesRetrieveCmd(),
 		newFilesListCmd(),
 	)
 
 	root.AddCommand(filesCmd)
+}
+
+// ---------------------------------------------------------------------------
+// files create (official ntn-compatible stdin / external URL entrypoint)
+// ---------------------------------------------------------------------------
+
+func newFilesCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a file upload",
+		Long:  "Upload bytes from stdin or import a public HTTPS URL as a Notion file upload.",
+		Args:  cobra.NoArgs,
+		RunE:  runFilesCreate,
+	}
+	cmd.Flags().String("filename", "", "Filename to store for stdin or external URL uploads")
+	cmd.Flags().String("content-type", "", "Content type override")
+	cmd.Flags().String("external-url", "", "Import a public HTTPS URL instead of reading stdin")
+	cmd.Flags().String("chunk-size", "10MB", "Chunk size for multi-part stdin uploads (5MB–20MB)")
+	cmd.Flags().Bool("plain", false, "Output tab-separated fields with upload ID first")
+	addOutputFlags(cmd)
+	return cmd
+}
+
+func runFilesCreate(cmd *cobra.Command, _ []string) error {
+	start := time.Now()
+	client, err := newClientForCommand(cmd)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+
+	filename, _ := cmd.Flags().GetString("filename")
+	contentType, _ := cmd.Flags().GetString("content-type")
+	externalURL, _ := cmd.Flags().GetString("external-url")
+	if externalURL != "" {
+		if err := validateExternalURL(externalURL, "--external-url"); err != nil {
+			return handleError(cmd, err)
+		}
+		body := map[string]any{
+			"mode":         "external_url",
+			"external_url": externalURL,
+		}
+		if filename != "" {
+			body["filename"] = filename
+		}
+		if contentType != "" {
+			body["content_type"] = contentType
+		}
+		result, err := client.FileUploadCreate(cmd.Context(), body)
+		if err != nil {
+			return handleError(cmd, err)
+		}
+		return printFileCommandResult(cmd, result, "files create", start)
+	}
+
+	data, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil {
+		return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Cannot read stdin", err))
+	}
+	if len(data) == 0 {
+		return handleError(cmd, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeMissingRequired,
+			Message: "No file bytes received on stdin",
+			Suggestions: []string{
+				"Redirect a file: notion-cli files create < ./photo.png",
+				"Or import a URL: notion-cli files create --external-url https://example.com/photo.png",
+			},
+		})
+	}
+	if filename == "" {
+		filename = "upload.bin"
+	}
+	if contentType == "" {
+		contentType = detectContentType(filename)
+	}
+	chunkSizeStr, _ := cmd.Flags().GetString("chunk-size")
+	chunkSize, err := parseChunkSize(chunkSizeStr)
+	if err != nil {
+		return handleError(cmd, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInvalidRequest,
+			Message: err.Error(),
+		})
+	}
+	result, err := uploadBytes(cmd, client, data, filename, contentType, chunkSize)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	return printFileCommandResult(cmd, result, "files create", start)
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +398,72 @@ func printUploadResult(cmd *cobra.Command, result map[string]any, start time.Tim
 	return nil
 }
 
+func uploadBytes(cmd *cobra.Command, client *notion.Client, data []byte, filename, contentType string, chunkSize int64) (map[string]any, error) {
+	ctx := cmd.Context()
+	fileSize := int64(len(data))
+	if fileSize <= singlePartMaxBytes {
+		createResult, err := client.FileUploadCreate(ctx, map[string]any{
+			"mode":         "single_part",
+			"filename":     filename,
+			"content_type": contentType,
+		})
+		if err != nil {
+			return nil, err
+		}
+		id, _ := createResult["id"].(string)
+		if id == "" {
+			return nil, &clierrors.NotionCLIError{
+				Code:    clierrors.CodeInternalError,
+				Message: "File upload create response missing id",
+			}
+		}
+		return client.FileUploadSend(ctx, id, 0, filename, contentType, data)
+	}
+
+	numParts := int((fileSize + chunkSize - 1) / chunkSize)
+	createResult, err := client.FileUploadCreate(ctx, map[string]any{
+		"mode":            "multi_part",
+		"filename":        filename,
+		"content_type":    contentType,
+		"number_of_parts": numParts,
+	})
+	if err != nil {
+		return nil, err
+	}
+	id, _ := createResult["id"].(string)
+	if id == "" {
+		return nil, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInternalError,
+			Message: "File upload create response missing id",
+		}
+	}
+	for i := 0; i < numParts; i++ {
+		start := int64(i) * chunkSize
+		end := start + chunkSize
+		if end > fileSize {
+			end = fileSize
+		}
+		if _, err := client.FileUploadSend(ctx, id, i+1, filename, contentType, data[start:end]); err != nil {
+			return nil, err
+		}
+	}
+	return client.FileUploadComplete(ctx, id)
+}
+
+func printFileCommandResult(cmd *cobra.Command, result map[string]any, command string, start time.Time) error {
+	plain, _ := cmd.Flags().GetBool("plain")
+	if plain {
+		id, _ := result["id"].(string)
+		filename, _ := result["filename"].(string)
+		status, _ := result["status"].(string)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", id, filename, status)
+		return nil
+	}
+	p := output.NewPrinter(outputFormat(cmd))
+	p.PrintSuccess(result, command, start)
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // files retrieve
 // ---------------------------------------------------------------------------
@@ -324,6 +478,7 @@ func newFilesRetrieveCmd() *cobra.Command {
 		RunE:    runFilesRetrieve,
 	}
 
+	cmd.Flags().Bool("plain", false, "Output tab-separated fields with upload ID first")
 	addOutputFlags(cmd)
 	return cmd
 }
@@ -341,9 +496,7 @@ func runFilesRetrieve(cmd *cobra.Command, args []string) error {
 		return handleError(cmd, err)
 	}
 
-	p := output.NewPrinter(outputFormat(cmd))
-	p.PrintSuccess(result, "files retrieve", start)
-	return nil
+	return printFileCommandResult(cmd, result, "files retrieve", start)
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +514,7 @@ func newFilesListCmd() *cobra.Command {
 
 	cmd.Flags().Int("page-size", 50, "Number of results per page")
 	cmd.Flags().Bool("all", false, "Paginate until all file uploads are retrieved")
+	cmd.Flags().Bool("plain", false, "Output tab-separated rows with upload ID first")
 
 	addOutputFlags(cmd)
 	return cmd
@@ -384,6 +538,10 @@ func runFilesList(cmd *cobra.Command, _ []string) error {
 		result, err := client.FileUploadList(ctx, qp)
 		if err != nil {
 			return handleError(cmd, err)
+		}
+		if plain, _ := cmd.Flags().GetBool("plain"); plain {
+			printFileListPlain(cmd, result)
+			return nil
 		}
 		p := output.NewPrinter(outputFormat(cmd))
 		p.PrintSuccess(result, "files list", start)
@@ -426,4 +584,15 @@ func runFilesList(cmd *cobra.Command, _ []string) error {
 	p := output.NewPrinter(outputFormat(cmd))
 	p.PrintSuccess(data, "files list", start)
 	return nil
+}
+
+func printFileListPlain(cmd *cobra.Command, result map[string]any) {
+	results, _ := result["results"].([]any)
+	for _, raw := range results {
+		m, _ := raw.(map[string]any)
+		id, _ := m["id"].(string)
+		filename, _ := m["filename"].(string)
+		status, _ := m["status"].(string)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", id, filename, status)
+	}
 }

--- a/internal/cli/commands/pages.go
+++ b/internal/cli/commands/pages.go
@@ -1,0 +1,196 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	clierrors "github.com/Coastal-Programs/notion-cli/v6/internal/errors"
+	"github.com/Coastal-Programs/notion-cli/v6/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+// RegisterPagesCommands adds official ntn-style page aliases without changing
+// the existing page command group.
+func RegisterPagesCommands(root *cobra.Command) {
+	pagesCmd := &cobra.Command{
+		Use:   "pages",
+		Short: "Official-style page operations",
+		Long:  "Official ntn-compatible page helpers for markdown get/create/update/trash workflows.",
+	}
+	pagesCmd.AddCommand(
+		newPagesGetCmd(),
+		newPagesCreateCmd(),
+		newPagesUpdateCmd(),
+		newPagesTrashCmd(),
+	)
+	root.AddCommand(pagesCmd)
+}
+
+func newPagesGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <page-id-or-url>",
+		Short: "Retrieve a page as Markdown",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runMarkdownGet,
+	}
+	addOutputFlags(cmd)
+	return cmd
+}
+
+func newPagesUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <page-id-or-url>",
+		Short: "Update a page from Markdown",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runMarkdownSet,
+	}
+	cmd.Flags().String("content", "", "Markdown content; reads stdin when omitted")
+	cmd.Flags().Bool("allow-deleting-content", false, "Allow deletion of child pages and databases")
+	addOutputFlags(cmd)
+	return cmd
+}
+
+func newPagesTrashCmd() *cobra.Command {
+	cmd := newPageTrashCmd()
+	cmd.Use = "trash <page-id-or-url>"
+	cmd.Short = "Trash a page"
+	return cmd
+}
+
+func newPagesCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a page from Markdown",
+		Args:  cobra.NoArgs,
+		RunE:  runPagesCreate,
+	}
+	cmd.Flags().String("parent", "", "Parent target: page:<id>, database:<id>, or data-source:<id>")
+	cmd.Flags().String("content", "", "Markdown content; reads stdin when omitted")
+	_ = cmd.MarkFlagRequired("parent")
+	addOutputFlags(cmd)
+	return cmd
+}
+
+func runPagesCreate(cmd *cobra.Command, _ []string) error {
+	start := time.Now()
+	parent, _ := cmd.Flags().GetString("parent")
+	content, _ := cmd.Flags().GetString("content")
+	if content == "" {
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return handleError(cmd, clierrors.Wrap(clierrors.CodeInternalError, "Cannot read stdin", err))
+		}
+		content = string(b)
+	}
+	if strings.TrimSpace(content) == "" {
+		return handleError(cmd, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeMissingRequired,
+			Message: "No markdown content provided",
+		})
+	}
+
+	client, err := newClientForCommand(cmd)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	parentBody, err := pagesParentBody(parent, content)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+
+	created, err := client.PageCreate(cmd.Context(), parentBody)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	pageID, _ := created["id"].(string)
+	if pageID == "" {
+		return handleError(cmd, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInternalError,
+			Message: "Page create response missing id",
+		})
+	}
+	updateBody := map[string]any{
+		"type":            "replace_content",
+		"replace_content": map[string]any{"new_str": content},
+	}
+	updated, err := client.PageMarkdownUpdate(cmd.Context(), pageID, updateBody)
+	if err != nil {
+		return handleError(cmd, err)
+	}
+	p := output.NewPrinter(outputFormat(cmd))
+	p.PrintSuccess(map[string]any{
+		"page":     created,
+		"markdown": updated,
+	}, "pages create", start)
+	return nil
+}
+
+func pagesParentBody(parent, content string) (map[string]any, error) {
+	kind, rawID, ok := strings.Cut(parent, ":")
+	if !ok || rawID == "" {
+		return nil, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInvalidRequest,
+			Message: "--parent must be page:<id>, database:<id>, or data-source:<id>",
+		}
+	}
+	id, err := resolveID(rawID)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case "page":
+		return map[string]any{
+			"parent": map[string]any{
+				"type":    "page_id",
+				"page_id": id,
+			},
+		}, nil
+	case "database":
+		return map[string]any{
+			"parent": map[string]any{
+				"type":        "database_id",
+				"database_id": id,
+			},
+			"properties": defaultPageProperties(content),
+		}, nil
+	case "data-source", "data_source", "datasource":
+		return map[string]any{
+			"parent": map[string]any{
+				"type":           "data_source_id",
+				"data_source_id": id,
+			},
+			"properties": defaultPageProperties(content),
+		}, nil
+	default:
+		return nil, &clierrors.NotionCLIError{
+			Code:    clierrors.CodeInvalidRequest,
+			Message: fmt.Sprintf("Unsupported parent type %q", kind),
+		}
+	}
+}
+
+func defaultPageProperties(content string) map[string]any {
+	title := firstMarkdownHeading(content)
+	if title == "" {
+		title = "Untitled"
+	}
+	return map[string]any{
+		"Name": map[string]any{
+			"title": []map[string]any{
+				{"text": map[string]any{"content": title}},
+			},
+		},
+	}
+}
+
+func firstMarkdownHeading(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			return strings.TrimSpace(strings.TrimLeft(line, "#"))
+		}
+	}
+	return ""
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -58,6 +58,7 @@ func init() {
 	// are added per-command via addOutputFlags to avoid redefinition panics).
 	pf := rootCmd.PersistentFlags()
 	pf.BoolP("verbose", "v", false, "Enable verbose stderr logging")
+	pf.String("notion-version", "", "Override Notion-Version header (or NOTION_API_VERSION)")
 	commands.AddAuthWorkspaceFlag(rootCmd)
 
 	// Version template.
@@ -68,6 +69,7 @@ func init() {
 	commands.RegisterDBCommands(rootCmd)
 	commands.RegisterDataSourceCommands(rootCmd)
 	commands.RegisterPageCommands(rootCmd)
+	commands.RegisterPagesCommands(rootCmd)
 	commands.RegisterBlockCommands(rootCmd)
 	commands.RegisterUserCommands(rootCmd)
 	commands.RegisterSearchCommand(rootCmd)
@@ -79,11 +81,13 @@ func init() {
 	commands.RegisterConfigCommands(rootCmd)
 	commands.RegisterCacheCommands(rootCmd)
 	commands.RegisterAuthCommands(rootCmd)
+	commands.RegisterRootAuthAliases(rootCmd)
 	commands.RegisterCommentCommands(rootCmd)
 	commands.RegisterViewCommands(rootCmd)
 	commands.RegisterCustomEmojiCommands(rootCmd)
 	commands.RegisterMarkdownCommands(rootCmd)
 	commands.RegisterFilesCommands(rootCmd)
+	commands.RegisterAPICommands(rootCmd)
 }
 
 // ExitCode returns the appropriate exit code for an error.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,11 +52,12 @@ func looksConfiguredOAuthValue(value string) bool {
 
 // Config holds all CLI configuration values.
 type Config struct {
-	Token       string `json:"token,omitempty"`
-	BaseURL     string `json:"base_url,omitempty"`
-	MaxRetries  int    `json:"max_retries,omitempty"`
-	BaseDelayMs int    `json:"base_delay_ms,omitempty"`
-	MaxDelayMs  int    `json:"max_delay_ms,omitempty"`
+	Token         string `json:"token,omitempty"`
+	BaseURL       string `json:"base_url,omitempty"`
+	NotionVersion string `json:"notion_version,omitempty"`
+	MaxRetries    int    `json:"max_retries,omitempty"`
+	BaseDelayMs   int    `json:"base_delay_ms,omitempty"`
+	MaxDelayMs    int    `json:"max_delay_ms,omitempty"`
 	// CacheEnabled, CacheMaxSize, DiskCacheEnabled are reserved for a future
 	// in-memory/disk response cache. They are persisted and exposed via
 	// `config get/set` for forward compatibility but currently have no effect
@@ -112,6 +113,9 @@ func (c *Config) AuthMethod() string {
 	if os.Getenv("NOTION_TOKEN") != "" {
 		return "env"
 	}
+	if os.Getenv("NOTION_API_TOKEN") != "" {
+		return "env"
+	}
 	if c.OAuthAccessToken != "" {
 		return "oauth"
 	}
@@ -125,6 +129,7 @@ func (c *Config) AuthMethod() string {
 func defaults() *Config {
 	return &Config{
 		BaseURL:          "https://api.notion.com/v1",
+		NotionVersion:    "2026-03-11",
 		MaxRetries:       3,
 		BaseDelayMs:      1000,
 		MaxDelayMs:       30000,
@@ -199,6 +204,9 @@ func loadFromFile(cfg *Config) error {
 	if fileCfg.BaseURL != "" {
 		cfg.BaseURL = fileCfg.BaseURL
 	}
+	if fileCfg.NotionVersion != "" {
+		cfg.NotionVersion = fileCfg.NotionVersion
+	}
 	if fileCfg.OAuthAccessToken != "" {
 		cfg.OAuthAccessToken = fileCfg.OAuthAccessToken
 	}
@@ -253,9 +261,14 @@ func loadFromFile(cfg *Config) error {
 func loadFromEnv(cfg *Config) {
 	if v := os.Getenv("NOTION_TOKEN"); v != "" {
 		cfg.Token = v
+	} else if v := os.Getenv("NOTION_API_TOKEN"); v != "" {
+		cfg.Token = v
 	}
 	if v := os.Getenv("NOTION_CLI_BASE_URL"); v != "" {
 		cfg.BaseURL = v
+	}
+	if v := os.Getenv("NOTION_API_VERSION"); v != "" {
+		cfg.NotionVersion = v
 	}
 	if v, err := strconv.Atoi(os.Getenv("NOTION_CLI_MAX_RETRIES")); err == nil {
 		cfg.MaxRetries = v
@@ -334,6 +347,8 @@ func GetConfigValue(key string) string {
 		return cfg.Token
 	case "base_url":
 		return cfg.BaseURL
+	case "notion_version":
+		return cfg.NotionVersion
 	case "max_retries":
 		return strconv.Itoa(cfg.MaxRetries)
 	case "base_delay_ms":

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -122,7 +122,7 @@ func TokenMissing() *NotionCLIError {
 		Suggestions: []string{
 			"Run an API command in an interactive terminal to start first-time OAuth setup",
 			"Run 'notion-cli auth login' to authenticate via OAuth",
-			"Or set the NOTION_TOKEN environment variable",
+			"Or set the NOTION_TOKEN / NOTION_API_TOKEN environment variable",
 			"Or run 'notion-cli config set-token <token>' for manual setup",
 			"Get a token at https://www.notion.so/my-integrations",
 		},

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -54,6 +54,23 @@ type QueryParams struct {
 	PageID      string
 }
 
+// RawRequest describes a generic Notion API request.
+type RawRequest struct {
+	Method      string
+	Path        string
+	Query       url.Values
+	Headers     http.Header
+	Body        []byte
+	ContentType string
+}
+
+// RawResponse captures the status, headers, and body for a generic API call.
+type RawResponse struct {
+	StatusCode int
+	Headers    http.Header
+	Body       []byte
+}
+
 // Values converts QueryParams to url.Values for use in HTTP requests.
 func (q QueryParams) Values() url.Values {
 	v := url.Values{}
@@ -475,6 +492,49 @@ func (c *Client) FileUploadList(ctx context.Context, query QueryParams) (map[str
 	return c.get(ctx, "/file_uploads", query.Values())
 }
 
+// Raw executes a generic Notion API request. It is used by the ntn-compatible
+// `api` command for endpoints that do not have a typed wrapper yet.
+func (c *Client) Raw(ctx context.Context, raw RawRequest) (*RawResponse, error) {
+	if raw.Method == "" {
+		raw.Method = http.MethodGet
+	}
+	u, err := c.rawURL(raw.Path, raw.Query)
+	if err != nil {
+		return nil, err
+	}
+	result, err := c.rawInternal(ctx, raw.Method, u, raw.Headers, raw.Body, raw.ContentType)
+	if err == nil {
+		return result, nil
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != 401 {
+		return nil, err
+	}
+	clientID, clientSecret, ok := config.OAuthClientCredentials()
+	if c.cfg == nil || c.cfg.OAuthRefreshToken == "" || !ok {
+		return nil, err
+	}
+	newToken, refreshErr := oauth.TokenRefresh(ctx, clientID, clientSecret, c.cfg.OAuthRefreshToken)
+	if refreshErr != nil {
+		return nil, err
+	}
+	c.token = newToken.AccessToken
+	c.cfg.OAuthAccessToken = newToken.AccessToken
+	if newToken.RefreshToken != "" {
+		c.cfg.OAuthRefreshToken = newToken.RefreshToken
+	}
+	if newToken.ExpiresIn > 0 {
+		c.cfg.OAuthTokenExpiresAt = time.Now().Add(
+			time.Duration(newToken.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
+	}
+	if c.cfgSaver != nil {
+		_ = c.cfgSaver(c.cfg)
+	} else {
+		_ = config.SaveConfig(c.cfg)
+	}
+	return c.rawInternal(ctx, raw.Method, u, raw.Headers, raw.Body, raw.ContentType)
+}
+
 // --- Internal HTTP helpers ---
 
 func (c *Client) get(ctx context.Context, path string, params url.Values) (map[string]any, error) {
@@ -533,6 +593,128 @@ func (c *Client) do(ctx context.Context, method, path string, params url.Values,
 	}
 
 	return c.doInternal(ctx, method, path, params, body) // retry once
+}
+
+func (c *Client) rawURL(path string, params url.Values) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("empty API path")
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		u, err := url.Parse(path)
+		if err != nil {
+			return "", err
+		}
+		q := u.Query()
+		for k, values := range params {
+			for _, v := range values {
+				q.Add(k, v)
+			}
+		}
+		u.RawQuery = q.Encode()
+		return u.String(), nil
+	}
+	path = strings.TrimLeft(path, "/")
+	if !strings.HasPrefix(path, "v1/") {
+		path = "v1/" + path
+	}
+	base := strings.TrimRight(c.baseURL, "/")
+	base = strings.TrimSuffix(base, "/v1")
+	u, err := url.Parse(base + "/" + path)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	for k, values := range params {
+		for _, v := range values {
+			q.Add(k, v)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (c *Client) rawInternal(ctx context.Context, method, rawURL string, headers http.Header, body []byte, contentType string) (*RawResponse, error) {
+	var result *RawResponse
+	err := retry.Do(ctx, *c.retryConfig, func() error {
+		req, err := http.NewRequestWithContext(ctx, method, rawURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Notion-Version", c.notionVersion)
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Accept-Encoding", "gzip")
+		if len(body) > 0 && contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		for k, values := range headers {
+			req.Header.Del(k)
+			for _, v := range values {
+				req.Header.Add(k, v)
+			}
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			if method == http.MethodGet {
+				return &retry.RetryableError{Err: fmt.Errorf("execute request: %w", err)}
+			}
+			return fmt.Errorf("execute request: %w", err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		var reader io.Reader = resp.Body
+		if resp.Header.Get("Content-Encoding") == "gzip" {
+			gr, err := gzip.NewReader(resp.Body)
+			if err != nil {
+				return fmt.Errorf("create gzip reader: %w", err)
+			}
+			defer gr.Close() //nolint:errcheck
+			reader = gr
+		}
+
+		const maxResponseSize = 50 * 1024 * 1024
+		respBody, err := io.ReadAll(io.LimitReader(reader, maxResponseSize))
+		if err != nil {
+			return fmt.Errorf("read response body: %w", err)
+		}
+
+		if resp.StatusCode >= 400 {
+			var apiErr APIError
+			if jsonErr := json.Unmarshal(respBody, &apiErr); jsonErr != nil {
+				apiErr = APIError{
+					Status:  resp.StatusCode,
+					Code:    "unknown",
+					Message: string(respBody),
+				}
+			}
+			apiErr.Status = resp.StatusCode
+			if retry.IsRetryable(resp.StatusCode) {
+				retryAfter := parseDuration(resp.Header.Get("Retry-After"))
+				return &retry.RetryableError{
+					Err:        &apiErr,
+					StatusCode: resp.StatusCode,
+					RetryAfter: retryAfter,
+				}
+			}
+			return &apiErr
+		}
+
+		result = &RawResponse{
+			StatusCode: resp.StatusCode,
+			Headers:    resp.Header.Clone(),
+			Body:       respBody,
+		}
+		return nil
+	})
+	if err != nil {
+		if retryErr, ok := err.(*retry.RetryableError); ok {
+			return nil, retryErr.Err
+		}
+		return nil, err
+	}
+	return result, nil
 }
 
 func (c *Client) doInternal(ctx context.Context, method, path string, params url.Values, body map[string]any) (map[string]any, error) {

--- a/scripts/refresh_notion_api_catalog.sh
+++ b/scripts/refresh_notion_api_catalog.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refresh helper for the embedded `notion-cli api` endpoint catalog.
+#
+# The checked-in catalog in internal/cli/commands/api_catalog.go is intentionally
+# deterministic and offline. This script gives maintainers a repeatable starting
+# point for comparing it with the current official docs index before updating
+# the Go source by hand.
+
+curl -fsSL https://developers.notion.com/llms.txt


### PR DESCRIPTION
## Summary

- add an `api <path>` command with ntn-compatible inline body, query, header, stdin, JSON, multipart, method, and raw-response handling
- add compatibility aliases for login/logout, data sources, pages, and files
- add Notion token/version environment aliases plus per-request `--notion-version`
- embed an API endpoint catalog with `ls`, `--spec`, and `--docs` introspection
- document the new command and compatibility surface

## Upstream sync

Rebased onto upstream `main` at `e76dfa3`. This deliberately leaves behind the fork commits already incorporated upstream by #90 and #107. Conflict resolution preserved the current workspace OAuth token masking and placed the API-parity entries under `Unreleased`.

## Verification

- `make fmt`
- `make test`
- `make build`
- `make lint`
- live read-only `./build/notion-cli --auth-workspace haven api users/me --json`
- `./build/notion-cli api ls --json`